### PR TITLE
Refactor waypoint APIs with notifier and query interfaces

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -215,6 +215,9 @@
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\MovementMonitor.cs" />
     <Compile Include="Assets\Scripts\OBSOLETE\WarpOnPlayerTouch.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IRobotNavigationListener.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\IWaypointNotifier.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\IWaypointQueries.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\IWaypointService.cs" />
     <Compile Include="Assets\Scripts\Managers\InterestPointManager.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\DropdownSample.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\VertexColorCycler.cs" />

--- a/Assets/Scripts/Interfaces/IWaypointNotifier.cs
+++ b/Assets/Scripts/Interfaces/IWaypointNotifier.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public interface IWaypointNotifier
+{
+    void Subscribe(IRobotNavigationListener robot);
+    void Unsubscribe(IRobotNavigationListener robot);
+    void NotifyWaypointStatusChanged(RoomWaypoint changed, bool isAvailable);
+}

--- a/Assets/Scripts/Interfaces/IWaypointNotifier.cs.meta
+++ b/Assets/Scripts/Interfaces/IWaypointNotifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: def018d70b224df99f0396afd4583a6b

--- a/Assets/Scripts/Interfaces/IWaypointQueries.cs
+++ b/Assets/Scripts/Interfaces/IWaypointQueries.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IWaypointQueries
+{
+    List<RoomWaypoint> GetActiveWaypoints();
+    List<RoomWaypoint> FindWorldPath(RoomWaypoint start, RoomWaypoint end);
+    RoomWaypoint GetClosestWaypoint(Vector2 position);
+    RoomWaypoint GetEndPoint();
+    void UpdateClosestWaypointToPlayer(Vector2 playerPosition);
+    RoomWaypoint ClosestWaypointToPlayer { get; }
+}

--- a/Assets/Scripts/Interfaces/IWaypointQueries.cs.meta
+++ b/Assets/Scripts/Interfaces/IWaypointQueries.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a553ccb42eaf4dcaa5dde9c57e027ea0

--- a/Assets/Scripts/Interfaces/IWaypointService.cs
+++ b/Assets/Scripts/Interfaces/IWaypointService.cs
@@ -1,26 +1,16 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public interface IWaypointService
+public interface IWaypointService : IWaypointNotifier, IWaypointQueries
 {
     void RegisterRoomWaypoints(RoomManager room, IEnumerable<RoomWaypoint> waypoints);
     void UnregisterRoomWaypoints(RoomManager room);
-    void NotifyWaypointStatusChanged(RoomWaypoint changed, bool isAvailable);
-
-    void Subscribe(IRobotNavigationListener robot);
-    void Unsubscribe(IRobotNavigationListener robot);
 
     void BuildAllNeighbors();
-    List<RoomWaypoint> FindWorldPath(RoomWaypoint start, RoomWaypoint end);
 
-    List<RoomWaypoint> GetActiveWaypoints();
     RoomWaypoint GetLeastUsedFreeWorkPoint(RoomWaypoint exclude = null);
     RoomWaypoint GetWorkOrRestPoint(RoomWaypoint exclude = null);
     RoomWaypoint GetFirstRestPoint(RoomWaypoint exclude = null);
     RoomWaypoint GetFirstFreeSecurityPoint();
-    RoomWaypoint GetEndPoint();
     void ReleasePOI(RoomWaypoint poi);
-
-    void UpdateClosestWaypointToPlayer(Vector2 playerPosition);
-    RoomWaypoint ClosestWaypointToPlayer { get; }
 }

--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -83,7 +83,7 @@ public class EnemiesSpawner : MonoBehaviour
 
             // 3) NOW it’s in the world at the correct spot — initialize its AI
             var ec = enemy.GetComponent<EnemyController>();
-            ec.Initialize(waypointService, this);
+            ec.Initialize(waypointService, waypointService, this);
 
             Debug.Log($"Enemy spread to {spawnPos} and initialized");
         }
@@ -108,7 +108,7 @@ public class EnemiesSpawner : MonoBehaviour
 
             // 3) NOW it’s in the world at the correct spot — initialize its AI
             var ec = enemy.GetComponent<EnemyBossController>();
-            ec.Initialize(waypointService, this);
+            ec.Initialize(waypointService, waypointService, this);
 
             Debug.Log($"Boss spread to {spawnPos} and initialized");
         }
@@ -143,7 +143,7 @@ public class EnemiesSpawner : MonoBehaviour
 
         // 4) Initialize its AI (waypoint service, etc.)
         var ec = enemyGO.GetComponent<EnemyController>();
-        ec.Initialize(waypointService, this);
+        ec.Initialize(waypointService, waypointService, this);
 
         // 5) Let its Memory know who the spawner is, so it can call back on “OnStuck”
         var mem = enemyGO.GetComponent<EnemyMemory>();


### PR DESCRIPTION
## Summary
- define `IWaypointNotifier` and `IWaypointQueries` interfaces
- make `IWaypointService` inherit from the new interfaces
- update enemy controllers to use notifier and query interfaces
- adjust spawner to pass interfaces
- register new files in the project file

## Testing
- `dotnet build -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868030e64108324961dd1d6313e65e1