### PR TITLE
Introduce ISaveService and refactor player save setup

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_TextEventHandler.cs" />
     <Compile Include="Assets\Tests\TestingPlaceholders\SquareMover.cs" />
     <Compile Include="Assets\Scripts\Game\LoadRunSetupScene.cs" />
+    <Compile Include="Assets\Scripts\Game\FactorySetupLoader.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\EnvMapAnimator.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IMover.cs" />
     <Compile Include="Assets\Scripts\Robots\AlternatingToggle.cs" />
@@ -203,6 +204,7 @@
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\Benchmark01.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TextMeshSpawner.cs" />
     <Compile Include="Assets\Scripts\Player\Data\PlayerSaveService.cs" />
+    <Compile Include="Assets\Scripts\Player\Interfaces\ISaveService.cs" />
     <Compile Include="Assets\Scripts\Navigation\UsageType.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Enemy_Idle.cs" />
     <Compile Include="Assets\Scripts\Player\Interfaces\IPlayerInput.cs" />

--- a/Assets/Scripts/Game/FactorySetupLoader.cs
+++ b/Assets/Scripts/Game/FactorySetupLoader.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class FactorySetupLoader : MonoBehaviour
+{
+    public void LoadFactorySetup()
+    {
+        SceneManager.LoadScene("RunSetupScene");
+    }
+}

--- a/Assets/Scripts/Game/FactorySetupLoader.cs.meta
+++ b/Assets/Scripts/Game/FactorySetupLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13026cdac6cb4f9282a1deb54b7d834d

--- a/Assets/Scripts/Game/SceneInitiator.cs
+++ b/Assets/Scripts/Game/SceneInitiator.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 
+
 public class SceneInitiator : GameInitiator
 {
     private IFactoryManager factoryManager;
@@ -12,6 +13,7 @@ public class SceneInitiator : GameInitiator
     private IRobotRespawnService respawnService;
     private RunMapConfigSO mapConfig;
     private VictorySetup victorySetup;
+    private ISaveService saveService;
 
      private SceneController sceneController;
 
@@ -25,7 +27,8 @@ public class SceneInitiator : GameInitiator
         IWaypointService waypointService,
         IRobotRespawnService respawnService,
         RunMapConfigSO mapConfig,
-        VictorySetup victorySetup)
+        VictorySetup victorySetup,
+        ISaveService saveService)
     {
         this.factoryManager = factoryManager;
         this.sceneControllerPrefab = sceneControllerPrefab;
@@ -37,6 +40,7 @@ public class SceneInitiator : GameInitiator
         this.respawnService = respawnService;
         this.mapConfig = mapConfig;
         this.victorySetup = victorySetup;
+        this.saveService = saveService;
 
         InitializeSceneSpecificObjects();
     }
@@ -63,7 +67,7 @@ public class SceneInitiator : GameInitiator
 
         playerInitiator.SetPlayerStartPosition(startPos);
 
-        playerInitiator.InitializePlayer();
+        playerInitiator.InitializePlayer(saveService);
 
         factoryManager.SetPlayerInstanceHead(playerInitiator.playerInstance, playerInitiator.playerHeadTransform);
 

--- a/Assets/Scripts/Interfaces/IPlayerSpawner.cs
+++ b/Assets/Scripts/Interfaces/IPlayerSpawner.cs
@@ -1,10 +1,11 @@
 using UnityEngine;
 
+
 public interface IPlayerSpawner
 {
     GameObject playerInstance { get; }
     RobotStateController playerRobotBehaviour { get; }
     Transform playerHeadTransform { get; }
     void SetPlayerStartPosition(Vector3 startPosition);
-    void InitializePlayer();
+    void InitializePlayer(ISaveService saveService);
 }

--- a/Assets/Scripts/Player/Core/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/Core/PlayerSpawner.cs
@@ -22,7 +22,7 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
     /// Instantiates the player robot prefab, initializes its behavior and info,
     /// then finds the "Head" Transform nested under "WholeBody".
     /// </summary>
-    public void InitializePlayer()
+    public void InitializePlayer(ISaveService saveService)
     {
         // Instantiate the robot
         playerInstance = Instantiate(
@@ -33,7 +33,7 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
 
         // Setup behaviour and save-data info
         playerRobotBehaviour = playerTemplate.InitializePlayerStateController(playerInstance);
-        playerRobotInfo = playerTemplate.InitializePlayerStats(PlayerSaveService.Instance.CurrentSaveData);
+        playerRobotInfo = playerTemplate.InitializePlayerStats(saveService.CurrentSaveData);
 
         // Locate "WholeBody" container
         Transform wholeBody = playerInstance.transform.Find("WholeBody");

--- a/Assets/Scripts/Player/Data/PlayerSaveService.cs
+++ b/Assets/Scripts/Player/Data/PlayerSaveService.cs
@@ -1,29 +1,15 @@
 using System.IO;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-
-public class PlayerSaveService : MonoBehaviour
+public class PlayerSaveService : MonoBehaviour, ISaveService
 {
     [SerializeField] private PlayerTemplate runtimePlayerData; // Assign in the Inspector
 
     private static string saveFilePath => Path.Combine(Application.persistentDataPath, "savefileCowBoya.json");
     public SaveData CurrentSaveData { get; private set; }
 
-    // Singleton pattern to access PlayerSaveService easily
-    public static PlayerSaveService Instance { get; private set; }
-
     private void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-        }
-        else
-        {
-            Destroy(gameObject);
-        }
-
+        DontDestroyOnLoad(gameObject);
         LoadGame(); // Load game data when the game starts
     }
 
@@ -72,9 +58,4 @@ public class PlayerSaveService : MonoBehaviour
         Debug.Log("Save data reset.");
     }
 
-    // Method to handle loading the base camp scene with save data
-    public void LoadFactorySetup()
-    {
-        SceneManager.LoadScene("RunSetupScene");
-    }
 }

--- a/Assets/Scripts/Player/Interfaces/ISaveService.cs
+++ b/Assets/Scripts/Player/Interfaces/ISaveService.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+public interface ISaveService
+{
+    SaveData CurrentSaveData { get; }
+    void SaveGame();
+    void LoadGame();
+    void ResetSaveData();
+}

--- a/Assets/Scripts/Player/Interfaces/ISaveService.cs.meta
+++ b/Assets/Scripts/Player/Interfaces/ISaveService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a92d05b490e3435f830fbd6a3fc2283a

--- a/Assets/Scripts/Setup/SceneBootstrapConfigSO.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapConfigSO.cs
@@ -12,5 +12,6 @@ public class SceneBootstrapConfigSO : ScriptableObject
     public SceneController sceneControllerPrefab;
     public GameUIViewModel gameUIViewModelPrefab;
     public VictorySetup victorySetupPrefab;
+    public PlayerSaveService saveServicePrefab;
     public RunMapConfigSO mapConfig;
 }

--- a/Assets/Scripts/Setup/SceneBootstrapper.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapper.cs
@@ -21,6 +21,7 @@ public class SceneBootstrapper : MonoBehaviour
         var sceneController = Instantiate(config.sceneControllerPrefab);
         var viewModel = Instantiate(config.gameUIViewModelPrefab);
         var victory = Instantiate(config.victorySetupPrefab);
+        var saveService = Instantiate(config.saveServicePrefab);
 
         var initiator = FindObjectOfType<SceneInitiator>();
         if (initiator != null)
@@ -35,7 +36,8 @@ public class SceneBootstrapper : MonoBehaviour
                 waypointService,
                 respawnService,
                 config.mapConfig,
-                victory
+                victory,
+                saveService
             );
         }
     }


### PR DESCRIPTION
## Summary
- add a new `ISaveService` interface
- remove singleton from `PlayerSaveService` and implement interface
- inject save service through scene bootstrapping
- update player spawner API for save service dependency
- move `LoadFactorySetup` logic into `FactorySetupLoader`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba8e415e88324a4baa95edb7a2805