### PR TITLE
Add interfaces for enemy controllers

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -234,6 +234,9 @@
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\EnemyWorkerController.cs" />
     <Compile Include="Assets\Scripts\OBSOLETE\WarpOnPlayerTouch.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IRobotNavigationListener.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\IEnemyStateMachine.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\IWorkerStateMachine.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\IRobotMemory.cs" />
     <Compile Include="Assets\Scripts\Managers\InterestPointManager.cs" />
     <Compile Include="Assets\Scripts\Robots\Module.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\DropdownSample.cs" />

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -4,7 +4,11 @@ using System.Collections;
 [RequireComponent(typeof(EnemyStateMachine), typeof(RobotMemory))]
 public class EnemyController : PhysicsBaseAgentController
 {
-    private EnemyStateMachine stateMachine;
+    [SerializeField] private EnemyStateMachine stateMachine;
+    [SerializeField] private RobotMemory memoryComponent;
+
+    private IEnemyStateMachine stateMachineInterface;
+    public IRobotMemory memory { get; private set; }
     private WaypointPathFollower pathFollower;
     private IWaypointQueries waypointQueries;
     private IWaypointNotifier waypointNotifier;
@@ -19,15 +23,19 @@ public class EnemyController : PhysicsBaseAgentController
     public Transform BodyReference => bodyReference;
 
     [SerializeField] private EnemyPunchAttack punchAttack;
-    public RobotMemory memory { get; private set; }
 
     [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
 
     protected override void Awake()
     {
         base.Awake();
-        stateMachine = GetComponent<EnemyStateMachine>();
-        memory = GetComponent<RobotMemory>();
+        if (stateMachine == null)
+            stateMachine = GetComponent<EnemyStateMachine>();
+        stateMachineInterface = stateMachine;
+
+        if (memoryComponent == null)
+            memoryComponent = GetComponent<RobotMemory>();
+        memory = memoryComponent;
 
         if (robotBehaviour == null)
             robotBehaviour = GetComponent<RobotStateController>();

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -4,7 +4,11 @@ using System.Collections;
 [RequireComponent(typeof(WorkerStateMachine), typeof(RobotMemory))]
 public class EnemyWorkerController : AnimatorBaseAgentController
 {
-    public WorkerStateMachine stateMachine;
+    [SerializeField] public WorkerStateMachine stateMachine;
+    [SerializeField] private RobotMemory memoryComponent;
+
+    private IWorkerStateMachine stateMachineInterface;
+    public IRobotMemory memory { get; private set; }
     private WaypointPathFollower pathFollower;
     private IWaypointQueries waypointQueries;
     public IWaypointService waypointService;
@@ -15,16 +19,19 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     [SerializeField] private float deadZoneX = 5f;
     [SerializeField] private float deadZoneY = 5f;
 
-    public RobotMemory memory { get; private set; }
-
     public WorkerStatus workerState { get; set; } = WorkerStatus.Idle;
-
     [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
 
     private void Awake()
     {
-        stateMachine = GetComponent<WorkerStateMachine>();
-        memory = GetComponent<RobotMemory>();
+        if (stateMachine == null)
+            stateMachine = GetComponent<WorkerStateMachine>();
+        stateMachineInterface = stateMachine;
+
+        if (memoryComponent == null)
+            memoryComponent = GetComponent<RobotMemory>();
+        memory = memoryComponent;
+
         animator = GetComponentInChildren<Animator>();
         robotBehaviour.OnStateChanged += HandleStateChange;
     }

--- a/Assets/Scripts/EnemyAI/Core/EnemyStateMachine.cs
+++ b/Assets/Scripts/EnemyAI/Core/EnemyStateMachine.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 /// <summary>
 /// Machine à états finis (FSM) pour gérer les différents comportements d'un ennemi.
 /// </summary>
-public class EnemyStateMachine : MonoBehaviour
+public class EnemyStateMachine : MonoBehaviour, IEnemyStateMachine
 {
     private EnemyState currentState;
 

--- a/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
+++ b/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 /// <summary>
 /// Stocke les informations mémorisées par l'ennemi, comme la dernière position connue du joueur, les agressions subies, etc.
 /// </summary>
-public class RobotMemory : MonoBehaviour
+public class RobotMemory : MonoBehaviour, IRobotMemory
 {
     [Header("Player Memory")]
     public Vector3 LastKnownPlayerPosition { get; private set; }

--- a/Assets/Scripts/EnemyAI/Core/WorkerStateMachine.cs
+++ b/Assets/Scripts/EnemyAI/Core/WorkerStateMachine.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 /// <summary>
 /// Machine à états finis (FSM) pour gérer les différents comportements d'un ennemi.
 /// </summary>
-public class WorkerStateMachine : MonoBehaviour
+public class WorkerStateMachine : MonoBehaviour, IWorkerStateMachine
 {
     private WorkerState currentState;
 

--- a/Assets/Scripts/Interfaces/IEnemyStateMachine.cs
+++ b/Assets/Scripts/Interfaces/IEnemyStateMachine.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+public interface IEnemyStateMachine
+{
+    void ChangeState(EnemyState newState);
+}

--- a/Assets/Scripts/Interfaces/IEnemyStateMachine.cs.meta
+++ b/Assets/Scripts/Interfaces/IEnemyStateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49f7d897b357469c8a705cdea989c217

--- a/Assets/Scripts/Interfaces/IRobotMemory.cs
+++ b/Assets/Scripts/Interfaces/IRobotMemory.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public interface IRobotMemory
+{
+    Vector3 LastKnownPlayerPosition { get; }
+    bool WasRecentlyAttacked { get; }
+    RoomWaypoint LastVisitedPoint { get; }
+
+    void SetRespawnService(IRobotRespawnService service);
+    void SetLastVisitedPoint(RoomWaypoint point);
+    void OnStuck(EnemyWorkerController controller);
+    void OnBossStuck(EnemyController controller);
+    void RememberPlayerPosition(Vector3 playerPosition);
+    void ClearPlayerPosition();
+    void RegisterAttack();
+    void ResetAttackMemory();
+}

--- a/Assets/Scripts/Interfaces/IRobotMemory.cs.meta
+++ b/Assets/Scripts/Interfaces/IRobotMemory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 286ab9b3652b41129d907bff81d8fe0b

--- a/Assets/Scripts/Interfaces/IWorkerStateMachine.cs
+++ b/Assets/Scripts/Interfaces/IWorkerStateMachine.cs
@@ -1,0 +1,4 @@
+public interface IWorkerStateMachine
+{
+    void ChangeState(WorkerState newState);
+}

--- a/Assets/Scripts/Interfaces/IWorkerStateMachine.cs.meta
+++ b/Assets/Scripts/Interfaces/IWorkerStateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88ed98a5276e435b8a8cee5ac15cea3e


### PR DESCRIPTION
## Summary
- define IEnemyStateMachine, IWorkerStateMachine and IRobotMemory
- implement these interfaces in state machine and memory classes
- refactor EnemyController and EnemyWorkerController to use serialized references with GetComponent fallbacks
- include new interface files in the project file

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686baf97d0788324921fbaba958938cb