### PR TITLE
Implement worker-machine manager

### DIFF
--- a/Assets/Doc/WorkerMachineFlow.md
+++ b/Assets/Doc/WorkerMachineFlow.md
@@ -1,0 +1,30 @@
+# Worker–Machine Interaction Flow
+
+This document describes how `MachineWorkerManager` reacts to machine state changes and directs workers.
+
+## Sequence
+1. **Subscribe**
+   - `MachineWorkerManager.SubscribeToMachineEvents` registers to every `FactoryMachine.OnMachineStateChanged` event.
+2. **Machine Turns Off**
+   - `HandleMachineStateChanged` calls `OnMachineTurnedOff`.
+   - The currently connected worker (`FactoryMachine.CurrentWorker`) is retrieved.
+   - If the machine is a `RestStation`, `AssignToStartRoom` sends the worker to the start room center.
+   - Otherwise `AssignToRestPoint` selects the nearest free rest waypoint via `WaypointService.GetFirstRestPoint`.
+   - The worker's activity state is updated to `Resting` or will become `Saved` upon arrival.
+3. **Machine Turns On**
+   - `HandleMachineStateChanged` calls `OnMachineTurnedOn`.
+   - Workers stored in `waitingWorkers` for this machine are notified and set back to `Active`.
+   - They may resume work on the machine (example pseudocode in code comments).
+
+## Target Selection
+- Rest points come from `WaypointService.GetFirstRestPoint`. When none are free, workers fall back to the start room via `AssignToStartRoom`.
+- The start room center is provided by `FactoryManager.GetStartCellWorldPosition` and converted to a waypoint using `WaypointService.GetClosestWaypoint`.
+
+## State Updates
+- `SetWorkerState` is a wrapper around `EnemyWorkerController.SetWorkerState` which updates the `WorkerCondition` enum (`Active`, `Resting`, `Saved`).
+- `Worker_GoingToStartRoom` switches to `Worker_Saved` once the worker reaches the start room, which triggers the global `RobotSaved` notification.
+
+## Edge Cases
+- **No free rest points**: `AssignToRestPoint` automatically calls `AssignToStartRoom`.
+- **Simultaneous machine toggles**: each event is processed individually; `waitingWorkers` tracks workers per machine so multiple toggles are handled gracefully.
+

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -20,6 +20,8 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     [SerializeField] private float deadZoneY = 5f;
 
     public WorkerStatus workerState { get; set; } = WorkerStatus.Idle;
+
+    public WorkerCondition activityState { get; private set; } = WorkerCondition.Active;
     [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
 
     private void Awake()
@@ -72,6 +74,11 @@ public class EnemyWorkerController : AnimatorBaseAgentController
 
     public RoomWaypoint GetClosestWaypoint(RoomWaypoint exclude = null) =>
         pathFollower.GetClosestWaypoint(exclude);
+
+    public void SetWorkerState(WorkerCondition newState)
+    {
+        activityState = newState;
+    }
 
     private void HandleStateChange(RobotState newState)
     {

--- a/Assets/Scripts/EnemyAI/Core/WorkerCondition.cs
+++ b/Assets/Scripts/EnemyAI/Core/WorkerCondition.cs
@@ -1,0 +1,7 @@
+public enum WorkerCondition
+{
+    Active,
+    Resting,
+    Saved
+}
+

--- a/Assets/Scripts/EnemyAI/States/Worker_GoingToStartRoom.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_GoingToStartRoom.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+public class Worker_GoingToStartRoom : WorkerState
+{
+    private RoomWaypoint target;
+    private bool hasArrived;
+
+    public Worker_GoingToStartRoom(EnemyWorkerController enemy,
+                                   WorkerStateMachine machine,
+                                   IWaypointService waypointService,
+                                   RoomWaypoint targetWp)
+        : base(enemy, machine, waypointService)
+    {
+        target = targetWp;
+        hasArrived = false;
+    }
+
+    public override void EnterState()
+    {
+        enemy.SetWorkerState(WorkerCondition.Active);
+        enemy.SetDestination(target);
+    }
+
+    public override void UpdateState()
+    {
+        if (hasArrived) return;
+
+        if (enemy.HasArrivedAtDestination())
+        {
+            hasArrived = true;
+            stateMachine.ChangeState(new Worker_Saved(enemy, stateMachine, waypointService));
+        }
+    }
+
+    public override void ExitState() {}
+}
+

--- a/Assets/Scripts/EnemyAI/States/Worker_Resting.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_Resting.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+public class Worker_Resting : WorkerState
+{
+    public Worker_Resting(EnemyWorkerController enemy, WorkerStateMachine machine, IWaypointService waypointService)
+        : base(enemy, machine, waypointService) { }
+
+    public override void EnterState()
+    {
+        enemy.SetWorkerState(WorkerCondition.Resting);
+        enemy.SetMovement(0f);
+    }
+
+    public override void UpdateState() {}
+
+    public override void ExitState() {}
+}
+

--- a/Assets/Scripts/EnemyAI/States/Worker_Saved.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_Saved.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public class Worker_Saved : WorkerState
+{
+    public Worker_Saved(EnemyWorkerController enemy, WorkerStateMachine machine, IWaypointService waypointService)
+        : base(enemy, machine, waypointService) { }
+
+    public override void EnterState()
+    {
+        enemy.SetWorkerState(WorkerCondition.Saved);
+        enemy.SetMovement(0f);
+        SceneController.instance?.RobotSaved();
+    }
+
+    public override void UpdateState() {}
+
+    public override void ExitState() {}
+}
+

--- a/Assets/Scripts/Machines/FactoryMachine.cs
+++ b/Assets/Scripts/Machines/FactoryMachine.cs
@@ -15,15 +15,21 @@ public class FactoryMachine : MonoBehaviour
     [SerializeField] private MeshRenderer meshRenderer;
     [SerializeField] private MachineType machineType;
 
+    public event System.Action<FactoryMachine, bool> OnMachineStateChanged;
+
     private EnemyWorkerController currentWorker;
     private bool haveWorkerConnected = false;
     public bool HaveWorkerConnected => haveWorkerConnected;
+    public MachineType MachineType => machineType;
+    public EnemyWorkerController CurrentWorker => currentWorker;
 
     public void SetState(bool on)
     {
+        if (isOn == on) return;
         Debug.Log($"Setting FactoryMachine state to {(on ? "On" : "Off")}");
         isOn = on;
         meshRenderer.material = on ? materialOn : materialOff;
+        OnMachineStateChanged?.Invoke(this, isOn);
     }
 
     public void Toggle()

--- a/Assets/Scripts/Machines/MachineWorkerManager.cs
+++ b/Assets/Scripts/Machines/MachineWorkerManager.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// Listens to FactoryMachine state changes and redirects workers accordingly.
+/// This script demonstrates the worker–machine interaction logic described in the documentation.
+/// </summary>
+public class MachineWorkerManager : MonoBehaviour
+{
+    [SerializeField] private FactoryManager factoryManager;
+    [SerializeField] private List<FactoryMachine> machines;
+
+    // Track workers waiting on a specific machine
+    private readonly Dictionary<EnemyWorkerController, FactoryMachine> waitingWorkers = new();
+
+    private void Awake()
+    {
+        SubscribeToMachineEvents();
+    }
+
+    /// <summary>
+    /// Subscribe to each machine's state change event.
+    /// </summary>
+    public void SubscribeToMachineEvents()
+    {
+        foreach (var m in machines)
+        {
+            if (m != null)
+                m.OnMachineStateChanged += HandleMachineStateChanged;
+        }
+    }
+
+    private void HandleMachineStateChanged(FactoryMachine machine, bool isOn)
+    {
+        if (isOn)
+            OnMachineTurnedOn(machine);
+        else
+            OnMachineTurnedOff(machine);
+    }
+
+    private void OnMachineTurnedOff(FactoryMachine machine)
+    {
+        var worker = machine.CurrentWorker;
+        if (worker == null)
+            return;
+
+        // Store that this worker was attached to this machine
+        waitingWorkers[worker] = machine;
+
+        if (machine.MachineType == MachineType.RestStation)
+            AssignToStartRoom(worker);
+        else
+            AssignToRestPoint(worker);
+    }
+
+    private void OnMachineTurnedOn(FactoryMachine machine)
+    {
+        // Any worker waiting for this machine may return to work
+        foreach (var pair in waitingWorkers.ToList())
+        {
+            if (pair.Value == machine)
+            {
+                var worker = pair.Key;
+                waitingWorkers.Remove(worker);
+                SetWorkerState(worker, WorkerCondition.Active);
+                // Pseudocode: tell worker to resume work on this machine
+                // worker.stateMachine.ChangeState(new Worker_GoingToLeastWorkedStation(worker, worker.stateMachine, worker.waypointService));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Send worker to nearest rest point. Falls back to start room if none free.
+    /// </summary>
+    public void AssignToRestPoint(EnemyWorkerController worker)
+    {
+        var rest = factoryManager.GetWayPointService().GetFirstRestPoint(worker.memory.LastVisitedPoint);
+        if (rest == null)
+        {
+            AssignToStartRoom(worker);
+            return;
+        }
+
+        worker.stateMachine.ChangeState(new Worker_GoingToRestStation(worker, worker.stateMachine, worker.waypointService));
+        worker.SetDestination(rest);
+        SetWorkerState(worker, WorkerCondition.Resting);
+    }
+
+    /// <summary>
+    /// Direct worker to the start room. When arrived they enter the Saved state.
+    /// </summary>
+    public void AssignToStartRoom(EnemyWorkerController worker)
+    {
+        Vector3 pos = factoryManager.GetStartCellWorldPosition();
+        RoomWaypoint wp = factoryManager.GetWayPointService().GetClosestWaypoint(pos);
+        worker.stateMachine.ChangeState(new Worker_GoingToStartRoom(worker, worker.stateMachine, worker.waypointService, wp));
+        worker.SetDestination(wp);
+    }
+
+    /// <summary>
+    /// Wrapper to update the worker activity state.
+    /// </summary>
+    public void SetWorkerState(EnemyWorkerController worker, WorkerCondition state)
+    {
+        worker.SetWorkerState(state);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `WorkerCondition` enum to track activity state
- extend `EnemyWorkerController` with `activityState` and setter
- expose machine events and details in `FactoryMachine`
- implement `MachineWorkerManager` to reassign workers when machines toggle
- create simple states (`Worker_Resting`, `Worker_Saved`, `Worker_GoingToStartRoom`)
- document worker-machine flow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c19ce89288324aaa9e6363c2e47c5