### PR TITLE
Fix worker resting state releasing waypoint

### DIFF
--- a/Assets/Scripts/EnemyAI/States/Worker_Resting.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_Resting.cs
@@ -11,6 +11,7 @@ public class Worker_Resting : WorkerState
     {
         enemy.workerState = WorkerStatus.Resting;
         enemy.SetMovement(0f);
+        _timer = 0f;
     }
 
     public override void UpdateState()
@@ -23,6 +24,9 @@ public class Worker_Resting : WorkerState
         }
     }
 
-    public override void ExitState() { }
+    public override void ExitState()
+    {
+        waypointService.ReleasePOI(enemy.memory.LastVisitedPoint);
+    }
 }
 


### PR DESCRIPTION
## Summary
- reset resting state timer on entry
- release rest point when exiting resting state

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fa00198ec8324839b90784ef7b04d