### PR TITLE
Fix machine off state worker cleanup

### DIFF
--- a/Assets/Scripts/Machines/FactoryMachine.cs
+++ b/Assets/Scripts/Machines/FactoryMachine.cs
@@ -38,6 +38,12 @@ public class FactoryMachine : MonoBehaviour
     public void SetState(bool on)
     {
         if (isOn == on) return;
+
+        if (!on)
+        {
+            SendCurrentWorkerToRest();
+        }
+
         isOn = on;
         ApplyMaterial();
         OnMachineStateChanged?.Invoke(this, isOn);
@@ -72,6 +78,7 @@ public class FactoryMachine : MonoBehaviour
         if (!isOn)
         {
             SendWorkerToRest(currentWorker);
+            currentWorker = null;
             SendWorkerToRest(newWorker);
         }
         else if (machineType == MachineType.WorkStation)
@@ -115,5 +122,14 @@ public class FactoryMachine : MonoBehaviour
         if (worker == null) return;
         worker.stateMachine.ChangeState(
             new Worker_IsWork(worker, worker.stateMachine, worker.waypointService));
+    }
+
+    /// <summary>
+    /// Sends the currently assigned worker to the rest station and clears the reference.
+    /// </summary>
+    private void SendCurrentWorkerToRest()
+    {
+        SendWorkerToRest(currentWorker);
+        currentWorker = null;
     }
 }


### PR DESCRIPTION
## Summary
- set current worker to null when machine is off in `OnWorkerReady`
- send any active worker to rest when calling `SetState(false)`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: unity command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa6a48c188324ac3bbd995ccb25db