### PR TITLE
Implement security guard spawn rules

### DIFF
--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -109,8 +109,19 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner
             }
             else
             {
-                //other enemies spawn at the first free security point
-                spawnPos = waypointService.GetFirstFreeSecurityPoint();
+                // Security guards spawn at POI security points, with a chance to use Rest points
+                bool useRest = Random.value < 0.5f;
+                spawnPos = useRest
+                    ? waypointService.GetFirstRestPoint()
+                    : waypointService.GetFirstFreeSecurityPoint();
+
+                // Fallback in case the chosen type has no free waypoint
+                if (spawnPos == null)
+                {
+                    spawnPos = useRest
+                        ? waypointService.GetFirstFreeSecurityPoint()
+                        : waypointService.GetFirstRestPoint();
+                }
             }
             enemy.transform.position = spawnPos.WorldPos;
 


### PR DESCRIPTION
## Summary
- spawn security guards only at POI security waypoints or rest points
- choose rest or security randomly and fall back if the selected type has no free points

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe9ce77888324bc87be512257d093