### PR TITLE
Add security guard machine reactivation system

### DIFF
--- a/Assets/Doc/SecurityGuardMachineFlow.md
+++ b/Assets/Doc/SecurityGuardMachineFlow.md
@@ -1,0 +1,16 @@
+# Security Guard – Machine Reactivation Flow
+
+This document outlines how security guards react when a `FactoryMachine` is switched off.
+
+1. **Registration**
+   - `MachineSecurityManager.RegisterMachine` subscribes to each machine's `OnMachineStateChanged` event.
+   - When a machine turns off, `MachineSecurityManager` raises `OnMachineTurnedOff`.
+2. **Notification**
+   - `SecurityGuardAI` components subscribe to `OnMachineTurnedOff` during initialization.
+   - Upon notification, the guard's state machine switches to `Enemy_ReactivateMachine` with the target machine.
+3. **Reactivation**
+   - `Enemy_ReactivateMachine` moves the guard to the closest waypoint near the machine.
+   - Once in range, it calls `FactoryMachine.SetState(true)` and returns the guard to `Enemy_SecurityGuardRest`.
+
+This shared state-machine approach keeps behaviour consistent across all robot types.
+

--- a/Assets/Scripts/EnemyAI/Controllers/SecurityGuardAI.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/SecurityGuardAI.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Component specific to security guards to react to machine shutdown events.
+/// </summary>
+[RequireComponent(typeof(EnemyController))]
+public class SecurityGuardAI : MonoBehaviour
+{
+    private EnemyController controller;
+    private EnemyStateMachine stateMachine;
+    private IWaypointService waypointService;
+    private MachineSecurityManager securityManager;
+
+    private void Awake()
+    {
+        controller = GetComponent<EnemyController>();
+        stateMachine = GetComponent<EnemyStateMachine>();
+    }
+
+    public void Initialize(IWaypointService service, MachineSecurityManager manager)
+    {
+        waypointService = service;
+        securityManager = manager;
+        if (securityManager != null)
+            securityManager.OnMachineTurnedOff += HandleMachineTurnedOff;
+    }
+
+    private void OnDestroy()
+    {
+        if (securityManager != null)
+            securityManager.OnMachineTurnedOff -= HandleMachineTurnedOff;
+    }
+
+    private void HandleMachineTurnedOff(FactoryMachine machine)
+    {
+        if (controller == null || stateMachine == null || waypointService == null)
+            return;
+        stateMachine.ChangeState(new Enemy_ReactivateMachine(controller, stateMachine, waypointService, machine));
+    }
+}
+

--- a/Assets/Scripts/EnemyAI/States/Enemy_ReactivateMachine.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_ReactivateMachine.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+/// <summary>
+/// Moves the guard to a disabled machine and reactivates it when close enough.
+/// </summary>
+public class Enemy_ReactivateMachine : EnemyState
+{
+    private readonly FactoryMachine targetMachine;
+    private RoomWaypoint targetPoint;
+    private bool hasArrived;
+
+    public Enemy_ReactivateMachine(
+        EnemyController enemy,
+        EnemyStateMachine machine,
+        IWaypointService waypointService,
+        FactoryMachine machineToActivate)
+        : base(enemy, machine, waypointService)
+    {
+        targetMachine = machineToActivate;
+    }
+
+    public override void EnterState()
+    {
+        hasArrived = false;
+        if (targetMachine == null)
+        {
+            stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
+            return;
+        }
+        targetPoint = waypointService.GetClosestWaypoint(targetMachine.transform.position);
+        enemy.SetDestination(targetPoint);
+    }
+
+    public override void UpdateState()
+    {
+        if (hasArrived) return;
+        if (enemy.HasArrivedAtDestination())
+        {
+            hasArrived = true;
+            enemy.SetMovement(0f);
+            enemy.SetVerticalMovement(0f);
+            targetMachine.SetState(true);
+            stateMachine.ChangeState(new Enemy_SecurityGuardRest(enemy, stateMachine, waypointService));
+        }
+    }
+
+    public override void ExitState() { }
+}
+

--- a/Assets/Scripts/FactoryCore/FactoryManager.cs
+++ b/Assets/Scripts/FactoryCore/FactoryManager.cs
@@ -7,6 +7,9 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
 {
     [SerializeField] private FactoryAlarmStatus factoryAlarmStatus;
     [SerializeField] private MachineWorkerManager machineWorkerManager;
+    [SerializeField] private MachineSecurityManager machineSecurityManager;
+
+    public MachineSecurityManager SecurityManager => machineSecurityManager;
 
     public event Action<AlarmState> OnFactoryAlarmChanged;
     private AlarmState lastAlarmState;
@@ -23,7 +26,7 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
         this.waypointService = waypointService;
         this.victorySetup = victorySetup;
         mapManager.InitializeGrid();
-        mapManager.RegisterFactoryInEachRoom(this, machineWorkerManager);
+        mapManager.RegisterFactoryInEachRoom(this, machineWorkerManager, machineSecurityManager);
         waypointService.BuildAllNeighbors();
         SetupFactoryState();
     }

--- a/Assets/Scripts/FactoryCore/RoomManager.cs
+++ b/Assets/Scripts/FactoryCore/RoomManager.cs
@@ -24,7 +24,8 @@ public class RoomManager : MonoBehaviour
     /// </summary>
     public void Initialize(
         FactoryManager factoryManager,
-        MachineWorkerManager machineWorkerManager)
+        MachineWorkerManager machineWorkerManager,
+        MachineSecurityManager machineSecurityManager)
     {
         FactoryManager = factoryManager;
 
@@ -41,6 +42,7 @@ public class RoomManager : MonoBehaviour
         {
             machine.Initialize(waypointService);
             machineWorkerManager.RegisterMachine(machine);
+            machineSecurityManager?.RegisterMachine(machine);
         }
 
         // 4) hook up alarm + triggers

--- a/Assets/Scripts/Game/SceneInitiator.cs
+++ b/Assets/Scripts/Game/SceneInitiator.cs
@@ -80,7 +80,7 @@ public class SceneInitiator : GameInitiator
 
     private void InitializeEnemies()
     {
-        enemiesSpawner?.Initialize(mapManager, waypointService, gameUIViewModel, respawnService);
+        enemiesSpawner?.Initialize(mapManager, waypointService, gameUIViewModel, respawnService, factoryManager.SecurityManager);
         enemiesSpawner?.CreateWorkers(mapConfig.workersCount);
         enemiesSpawner?.CreateEnemy(mapConfig.enemiesCount);
         enemiesSpawner?.SpreadEnemies();

--- a/Assets/Scripts/Machines/MachineSecurityManager.cs
+++ b/Assets/Scripts/Machines/MachineSecurityManager.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Notifies security guards when a factory machine turns off.
+/// Guards can subscribe to <see cref="OnMachineTurnedOff"/> to react.
+/// </summary>
+public class MachineSecurityManager : MonoBehaviour
+{
+    private readonly List<FactoryMachine> machines = new();
+
+    /// <summary>
+    /// Fired whenever a registered machine is switched off.
+    /// </summary>
+    public event Action<FactoryMachine> OnMachineTurnedOff;
+
+    public void RegisterMachine(FactoryMachine machine)
+    {
+        if (machine == null || machines.Contains(machine))
+            return;
+        machines.Add(machine);
+        machine.OnMachineStateChanged += HandleMachineStateChanged;
+    }
+
+    private void HandleMachineStateChanged(FactoryMachine machine, bool isOn)
+    {
+        if (!isOn)
+            OnMachineTurnedOff?.Invoke(machine);
+    }
+}
+

--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -10,16 +10,18 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner
     private MapManager mapManager;
     private IWaypointService waypointService;
     private IRobotRespawnService respawnService;
+    private MachineSecurityManager securityManager;
     private List<GameObject> spawnedWorkers = new List<GameObject>();
     private List<GameObject> spawnedEnemies = new List<GameObject>();
     private GameUIViewModel gameUIViewModel;
 
-    public void Initialize(MapManager mapManager, IWaypointService waypointService, GameUIViewModel viewModel, IRobotRespawnService respawnService)
+    public void Initialize(MapManager mapManager, IWaypointService waypointService, GameUIViewModel viewModel, IRobotRespawnService respawnService, MachineSecurityManager securityManager)
     {
         this.waypointService = waypointService;
         this.mapManager = mapManager;
         this.gameUIViewModel = viewModel;
         this.respawnService = respawnService;
+        this.securityManager = securityManager;
 
         if (respawnService is RobotRespawnService service)
             service.Initialize(this);
@@ -131,6 +133,8 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner
             // 3) NOW it’s in the world at the correct spot — initialize its AI
             var ec = enemy.GetComponent<EnemyController>();
             ec.Initialize(waypointService, waypointService, respawnService);
+            var guardAI = enemy.GetComponent<SecurityGuardAI>();
+            guardAI?.Initialize(waypointService, securityManager);
 
             if (spawnPos.type == WaypointType.Rest)
             {
@@ -174,6 +178,8 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner
         // 4) Initialize its AI (waypoint service, etc.)
         var ec = enemyGO.GetComponent<EnemyWorkerController>();
         ec.Initialize(waypointService, waypointService, respawnService);
+        var guardAI = enemyGO.GetComponent<SecurityGuardAI>();
+        guardAI?.Initialize(waypointService, securityManager);
 
         // 5) Keep track of it
         spawnedWorkers.Add(enemyGO);

--- a/Assets/Scripts/Navigation/MapManager.cs
+++ b/Assets/Scripts/Navigation/MapManager.cs
@@ -145,13 +145,13 @@ public class MapManager : MonoBehaviour
         };
     }
 
-    public void RegisterFactoryInEachRoom(FactoryManager factoryManager, MachineWorkerManager machineWorkerManager)
+    public void RegisterFactoryInEachRoom(FactoryManager factoryManager, MachineWorkerManager machineWorkerManager, MachineSecurityManager machineSecurityManager)
     {
         foreach (var roomGO in roomInstances.Values)
         {
             var rm = roomGO.GetComponent<RoomManager>();
             if (rm != null)
-                rm.Initialize(factoryManager, machineWorkerManager);
+                rm.Initialize(factoryManager, machineWorkerManager, machineSecurityManager);
         }
     }
 

--- a/Game.csproj
+++ b/Game.csproj
@@ -183,6 +183,9 @@
     <Compile Include="Assets\Scripts\Managers\EnemiesSpawner.cs" />
     <Compile Include="Assets\Scripts\Player\Controllers\PlayerAttackController.cs" />
     <Compile Include="Assets\Scripts\Machines\MachineWorkerManager.cs" />
+    <Compile Include="Assets\Scripts\Machines\MachineSecurityManager.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\Controllers\SecurityGuardAI.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\States\Enemy_ReactivateMachine.cs" />
     <Compile Include="Assets\Scripts\Player\Controllers\PlayerMovementController.cs" />
     <Compile Include="Assets\Scripts\Machines\ToggleBox.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\PhysicsBaseAgentController.cs" />


### PR DESCRIPTION
## Summary
- add `MachineSecurityManager` to notify guards of machine shutdowns
- implement `SecurityGuardAI` and `Enemy_ReactivateMachine` state
- connect new manager through `FactoryManager`, `MapManager` and `RoomManager`
- extend `EnemiesSpawner` and `SceneInitiator` to initialise guards with the new manager
- document the reactivation flow

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff6d87eec8324857e51337acb268d