### PR TITLE
Handle guards through MachineSecurityManager

### DIFF
--- a/Assets/Doc/SecurityGuardMachineFlow.md
+++ b/Assets/Doc/SecurityGuardMachineFlow.md
@@ -4,13 +4,12 @@ This document outlines how security guards react when a `FactoryMachine` is swit
 
 1. **Registration**
    - `MachineSecurityManager.RegisterMachine` subscribes to each machine's `OnMachineStateChanged` event.
-   - When a machine turns off, `MachineSecurityManager` raises `OnMachineTurnedOff`.
+   - Security guards call `RegisterGuard` during initialization so the manager can dispatch them.
 2. **Notification**
-   - `SecurityGuardAI` components subscribe to `OnMachineTurnedOff` during initialization.
-   - Upon notification, the guard's state machine switches to `Enemy_ReactivateMachine` with the target machine.
+   - When a machine turns off, `MachineSecurityManager` chooses the nearest available guard and calls `ReactivateMachine` on it.
 3. **Reactivation**
-   - `Enemy_ReactivateMachine` moves the guard to the closest waypoint near the machine.
-   - Once in range, it calls `FactoryMachine.SetState(true)` and returns the guard to `Enemy_SecurityGuardRest`.
+   - `SecurityGuardAI.ReactivateMachine` switches the guard to `Enemy_ReactivateMachine`.
+   - After turning the machine back on, the guard enters `Enemy_ReturnToSecurityPost` to go back to its previous post.
 
 This shared state-machine approach keeps behaviour consistent across all robot types.
 

--- a/Assets/Scripts/EnemyAI/Controllers/SecurityGuardAI.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/SecurityGuardAI.cs
@@ -21,21 +21,21 @@ public class SecurityGuardAI : MonoBehaviour
     {
         waypointService = service;
         securityManager = manager;
-        if (securityManager != null)
-            securityManager.OnMachineTurnedOff += HandleMachineTurnedOff;
+        securityManager?.RegisterGuard(this);
     }
 
     private void OnDestroy()
     {
-        if (securityManager != null)
-            securityManager.OnMachineTurnedOff -= HandleMachineTurnedOff;
+        securityManager?.UnregisterGuard(this);
     }
 
-    private void HandleMachineTurnedOff(FactoryMachine machine)
+    public void ReactivateMachine(FactoryMachine machine)
     {
         if (controller == null || stateMachine == null || waypointService == null)
             return;
-        stateMachine.ChangeState(new Enemy_ReactivateMachine(controller, stateMachine, waypointService, machine));
+        var returnPoint = controller.memory.LastVisitedPoint;
+        stateMachine.ChangeState(new Enemy_ReactivateMachine(
+            controller, stateMachine, waypointService, machine, returnPoint));
     }
 }
 

--- a/Assets/Scripts/EnemyAI/States/Enemy_ReactivateMachine.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_ReactivateMachine.cs
@@ -7,16 +7,19 @@ public class Enemy_ReactivateMachine : EnemyState
 {
     private readonly FactoryMachine targetMachine;
     private RoomWaypoint targetPoint;
+    private readonly RoomWaypoint returnPoint;
     private bool hasArrived;
 
     public Enemy_ReactivateMachine(
         EnemyController enemy,
         EnemyStateMachine machine,
         IWaypointService waypointService,
-        FactoryMachine machineToActivate)
+        FactoryMachine machineToActivate,
+        RoomWaypoint returnPoint)
         : base(enemy, machine, waypointService)
     {
         targetMachine = machineToActivate;
+        this.returnPoint = returnPoint;
     }
 
     public override void EnterState()
@@ -40,7 +43,7 @@ public class Enemy_ReactivateMachine : EnemyState
             enemy.SetMovement(0f);
             enemy.SetVerticalMovement(0f);
             targetMachine.SetState(true);
-            stateMachine.ChangeState(new Enemy_SecurityGuardRest(enemy, stateMachine, waypointService));
+            stateMachine.ChangeState(new Enemy_ReturnToSecurityPost(enemy, stateMachine, waypointService, returnPoint));
         }
     }
 

--- a/Assets/Scripts/EnemyAI/States/Enemy_ReturnToSecurityPost.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_ReturnToSecurityPost.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+/// <summary>
+/// Moves the guard back to a specific security waypoint.
+/// </summary>
+public class Enemy_ReturnToSecurityPost : EnemyState
+{
+    private readonly RoomWaypoint targetPoint;
+    private bool hasArrived;
+
+    public Enemy_ReturnToSecurityPost(
+        EnemyController enemy,
+        EnemyStateMachine machine,
+        IWaypointService waypointService,
+        RoomWaypoint securityPoint)
+        : base(enemy, machine, waypointService)
+    {
+        targetPoint = securityPoint;
+    }
+
+    public override void EnterState()
+    {
+        hasArrived = false;
+        if (targetPoint == null)
+        {
+            stateMachine.ChangeState(new Enemy_SecurityGuardRest(enemy, stateMachine, waypointService));
+            return;
+        }
+        enemy.SetDestination(targetPoint);
+    }
+
+    public override void UpdateState()
+    {
+        if (hasArrived) return;
+
+        if (enemy.HasArrivedAtDestination())
+        {
+            hasArrived = true;
+            enemy.SetMovement(0f);
+            enemy.SetVerticalMovement(0f);
+            enemy.memory.SetLastVisitedPoint(targetPoint);
+            stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
+        }
+    }
+
+    public override void ExitState() { }
+}

--- a/Game.csproj
+++ b/Game.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Assets\Scripts\Machines\MachineSecurityManager.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\SecurityGuardAI.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Enemy_ReactivateMachine.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\States\Enemy_ReturnToSecurityPost.cs" />
     <Compile Include="Assets\Scripts\Player\Controllers\PlayerMovementController.cs" />
     <Compile Include="Assets\Scripts\Machines\ToggleBox.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\PhysicsBaseAgentController.cs" />


### PR DESCRIPTION
## Summary
- track guards inside `MachineSecurityManager`
- register/unregister guards from `SecurityGuardAI`
- add `Enemy_ReturnToSecurityPost` state
- select closest guard when a machine powers off
- update docs on security guard flow

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687289e106e083249fb9f1ebc9c7c9ad