### PR TITLE
Update guard rest fallback behavior

### DIFF
--- a/Assets/Scripts/EnemyAI/States/Enemy_SecurityGuardRest.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_SecurityGuardRest.cs
@@ -32,9 +32,20 @@ public class Enemy_SecurityGuardRest : EnemyState
                 targetPoint = waypointService.GetFirstFreeSecurityPoint();
                 if (targetPoint == null)
                 {
+                    targetPoint = waypointService.GetFirstRestPoint();
+                }
+
+                if (targetPoint == null)
+                {
+                    targetPoint = waypointService.GetStartPoint();
+                }
+
+                if (targetPoint == null)
+                {
                     stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
                     return;
                 }
+
                 enemy.SetDestination(targetPoint);
                 moving = true;
             }
@@ -46,7 +57,10 @@ public class Enemy_SecurityGuardRest : EnemyState
             enemy.SetMovement(0f);
             enemy.SetVerticalMovement(0f);
             enemy.memory.SetLastVisitedPoint(targetPoint);
-            waypointService.ReleasePOI(targetPoint);
+            if (targetPoint.type == WaypointType.Security || targetPoint.type == WaypointType.Rest)
+            {
+                waypointService.ReleasePOI(targetPoint);
+            }
             stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
         }
     }

--- a/Assets/Tests/UnitTests/SecurityGuardRestTests.cs
+++ b/Assets/Tests/UnitTests/SecurityGuardRestTests.cs
@@ -1,0 +1,31 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class SecurityGuardRestTests
+{
+    private GameObject _gameObject;
+    private EnemyController _enemy;
+    private EnemyStateMachine _stateMachine;
+    private WaypointService _waypointService;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _gameObject = new GameObject();
+        _enemy = _gameObject.AddComponent<EnemyController>();
+        _stateMachine = _gameObject.AddComponent<EnemyStateMachine>();
+        _waypointService = _gameObject.AddComponent<WaypointService>();
+    }
+
+    [Test]
+    public void NoSecurityPoints_FallbackToRestPoint()
+    {
+        // TODO: Assert rest point fallback logic
+    }
+
+    [Test]
+    public void NoRestPoints_FallbackToStartPoint()
+    {
+        // TODO: Assert start point fallback logic
+    }
+}

--- a/Assets/Tests/UnitTests/SecurityGuardRestTests.cs.meta
+++ b/Assets/Tests/UnitTests/SecurityGuardRestTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba3ffe780e94612bfd2c466bfcf131ee


### PR DESCRIPTION
## Summary
- refine fallback logic when security guard can't find security station
- add skeleton unit tests for rest and start point fallback

## Testing
- `dotnet test UnitTests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728a08b40c8324ab76685ea9bd0e75