### PR TITLE
Refactor security guard attack flow

### DIFF
--- a/Assets/Scripts/EnemyAI/States/Enemy_AttackPlayer.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_AttackPlayer.cs
@@ -5,10 +5,15 @@ public class Enemy_AttackPlayer : EnemyState
 {
     private Vector3 playerTransform;
     private float stopDistance = 1.5f;
+    private readonly EnemyState previousState;
 
-    public Enemy_AttackPlayer(EnemyController enemy, EnemyStateMachine machine, IWaypointService waypointService)
+    public Enemy_AttackPlayer(EnemyController enemy,
+                              EnemyStateMachine machine,
+                              IWaypointService waypointService,
+                              EnemyState previousState)
         : base(enemy, machine, waypointService)
     {
+        this.previousState = previousState;
         playerTransform = enemy.memory.LastKnownPlayerPosition;
     }
 
@@ -24,7 +29,14 @@ public class Enemy_AttackPlayer : EnemyState
 
         if (playerTransform == Vector3.zero)
         {
-            stateMachine.ChangeState(new Enemy_GoToEndCell(enemy, stateMachine, waypointService));
+            if (previousState != null)
+            {
+                stateMachine.ChangeState(previousState);
+            }
+            else
+            {
+                stateMachine.ChangeState(new Enemy_GoToEndCell(enemy, stateMachine, waypointService));
+            }
             return;
         }
 

--- a/Assets/Scripts/EnemyAI/States/Enemy_GoToEndCell.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_GoToEndCell.cs
@@ -44,7 +44,7 @@ public class Enemy_GoToEndCell : EnemyState
     {
         if (enemy.memory.LastKnownPlayerPosition != Vector3.zero && enemy.memory.WasRecentlyAttacked)
         {
-            stateMachine.ChangeState(new Enemy_AttackPlayer(enemy, stateMachine, waypointService));
+            stateMachine.ChangeState(new Enemy_AttackPlayer(enemy, stateMachine, waypointService, this));
         }
         if (hasArrived) return;
 

--- a/Assets/Scripts/EnemyAI/States/Enemy_Idle.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_Idle.cs
@@ -20,7 +20,7 @@ public class Enemy_Idle : EnemyState
     {
         if (enemy.memory.LastKnownPlayerPosition != Vector3.zero && enemy.memory.WasRecentlyAttacked)
         {
-            stateMachine.ChangeState(new Enemy_AttackPlayer(enemy, stateMachine, waypointService));
+            stateMachine.ChangeState(new Enemy_AttackPlayer(enemy, stateMachine, waypointService, this));
         }
     }
 


### PR DESCRIPTION
## Summary
- allow `Enemy_AttackPlayer` to remember the previous state
- resume that previous state when losing track of the player
- pass the current state when transitioning to `Enemy_AttackPlayer`

## Testing
- `bash ./setup_env.sh` *(fails: 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68728a15870883249da07739c83080e2