### PR TITLE
Add ReadyToRest state for worker AI

### DIFF
--- a/Assets/Scripts/EnemyAI/States/WorkerState.cs
+++ b/Assets/Scripts/EnemyAI/States/WorkerState.cs
@@ -21,6 +21,7 @@ public abstract class WorkerState
 public enum WorkerStatus
 {
     ReadyToWork,
+    ReadyToRest,
     Working,
     GoingToWork,
     GoingToRest,

--- a/Assets/Scripts/EnemyAI/States/Worker_GoingToRestStation.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_GoingToRestStation.cs
@@ -50,6 +50,7 @@ public class Worker_GoingToRestStation : WorkerState
             enemy.SetVerticalMovement(0f);
 
             enemy.memory.SetLastVisitedPoint(targetPoint);
+            enemy.workerState = WorkerStatus.ReadyToRest;
             stateMachine.ChangeState(new Worker_Resting(enemy, stateMachine, waypointService));
 
         }

--- a/Assets/Scripts/Machines/WorkerSlot.cs
+++ b/Assets/Scripts/Machines/WorkerSlot.cs
@@ -8,7 +8,9 @@ public class WorkerSlot : MonoBehaviour
     {
         var enemy = collision.GetComponentInParent<EnemyWorkerController>();
         if (enemy == null) return;
-        if (enemy.workerState == WorkerStatus.ReadyToWork || enemy.workerState == WorkerStatus.Resting)
+        if (enemy.workerState == WorkerStatus.ReadyToWork ||
+            enemy.workerState == WorkerStatus.ReadyToRest ||
+            enemy.workerState == WorkerStatus.Resting)
         {
             machine.AttachRobot(enemy.gameObject);
         }


### PR DESCRIPTION
## Summary
- add a `ReadyToRest` value to `WorkerStatus`
- allow `WorkerSlot` to accept workers in the new state
- mark workers `ReadyToRest` when arriving at rest stations

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687684fd8d0c8324949b013a02ae3d87