### PR TITLE
Add worker spawner support

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -21,6 +21,8 @@ public class EnemyWorkerController : AnimatorBaseAgentController
 
     public WorkerStatus workerState { get; set; } = WorkerStatus.Idle;
 
+    public bool IsWorkerSpawner { get; private set; }
+
     [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
 
     private void Awake()
@@ -51,12 +53,14 @@ public class EnemyWorkerController : AnimatorBaseAgentController
 
     public void SetWorkerState()
     {
+        IsWorkerSpawner = false;
         stateMachine.ChangeState(new Worker_Idle(this, stateMachine, (IWaypointService)waypointQueries));
     }
 
     public void SetWorkerSpawnerState()
     {
-        stateMachine.ChangeState(new Worker_Spawning(this, stateMachine, (IWaypointService)waypointQueries));
+        IsWorkerSpawner = true;
+        stateMachine.ChangeState(new Worker_Idle(this, stateMachine, (IWaypointService)waypointQueries));
     }
 
     protected override void Update()

--- a/Assets/Scripts/EnemyAI/States/WorkerState.cs
+++ b/Assets/Scripts/EnemyAI/States/WorkerState.cs
@@ -29,5 +29,6 @@ public enum WorkerStatus
     Resting,
     GoingToStartRoom,
     Saved,
-    Spawning
+    Spawning,
+    GoingToSpawningMachine
 }

--- a/Assets/Scripts/EnemyAI/States/Worker_Idle.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_Idle.cs
@@ -30,7 +30,10 @@ public class Worker_Idle : WorkerState
             Debug.Log($"[Idle] {IDLE_DURATION} seconds elapsed → moving to next POI.");
             var returnPoint = enemy.memory.LastVisitedPoint;
             waypointService.ReleasePOI(returnPoint);
-            stateMachine.ChangeState(new Worker_GoingToLeastWorkedStation(enemy, stateMachine, waypointService));
+            if (enemy.IsWorkerSpawner)
+                stateMachine.ChangeState(new Worker_GoingToSpawningMachine(enemy, stateMachine, waypointService));
+            else
+                stateMachine.ChangeState(new Worker_GoingToLeastWorkedStation(enemy, stateMachine, waypointService));
         }
     }
 

--- a/Assets/Scripts/FactoryCore/FactoryManager.cs
+++ b/Assets/Scripts/FactoryCore/FactoryManager.cs
@@ -8,6 +8,7 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
     [SerializeField] public FactoryAlarmStatus factoryAlarmStatus;
     [SerializeField] private MachineWorkerManager machineWorkerManager;
     [SerializeField] private MachineSecurityManager machineSecurityManager;
+    [SerializeField] private SpawningWorkerManager spawningWorkerManager;
 
     public MachineSecurityManager SecurityManager => machineSecurityManager;
 
@@ -26,7 +27,7 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
         this.waypointService = waypointService;
         this.victorySetup = victorySetup;
         mapManager.InitializeGrid();
-        mapManager.RegisterFactoryInEachRoom(this, machineWorkerManager, machineSecurityManager,enemiesSpawner);
+        mapManager.RegisterFactoryInEachRoom(this, machineWorkerManager, machineSecurityManager, spawningWorkerManager, enemiesSpawner);
         waypointService.BuildAllNeighbors();
         SetupFactoryState();
     }

--- a/Assets/Scripts/FactoryCore/RoomManager.cs
+++ b/Assets/Scripts/FactoryCore/RoomManager.cs
@@ -29,6 +29,7 @@ public class RoomManager : MonoBehaviour
         FactoryManager factoryManager,
         MachineWorkerManager machineWorkerManager,
         MachineSecurityManager machineSecurityManager,
+        SpawningWorkerManager spawningWorkerManager,
         IEnemiesSpawner enemiesSpawner)
     {
         FactoryManager = factoryManager;
@@ -52,11 +53,13 @@ public class RoomManager : MonoBehaviour
         // 4) hook up alarm + triggers
         factoryManager.OnFactoryAlarmChanged += HandleFactoryAlarmChanged;
 
-        // 5) add the spawner to the spawning machines
-        if (enemiesSpawner != null){
+        // 5) register spawning machines
+        if (enemiesSpawner != null)
+        {
             foreach (var spawningMachine in spawningMachinesInRoom)
             {
                 spawningMachine.Initialize(enemiesSpawner);
+                spawningWorkerManager?.RegisterMachine(spawningMachine);
             }
         }
 

--- a/Assets/Scripts/Machines/SpawningWorkerManager.cs
+++ b/Assets/Scripts/Machines/SpawningWorkerManager.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Registers <see cref="SpawningMachine"/> instances with the
+/// <see cref="StationReservationService"/> so worker spawners can
+/// reserve them.
+/// </summary>
+public class SpawningWorkerManager : MonoBehaviour
+{
+    [SerializeField] private StationReservationService reservationService;
+
+    private readonly List<SpawningMachine> machines = new();
+
+    public void RegisterMachine(SpawningMachine machine)
+    {
+        if (machine == null || machines.Contains(machine))
+            return;
+        machines.Add(machine);
+        reservationService?.RegisterMachine(machine, RobotRole.WorkerSpawner);
+    }
+}

--- a/Assets/Scripts/Navigation/MapManager.cs
+++ b/Assets/Scripts/Navigation/MapManager.cs
@@ -149,13 +149,14 @@ public class MapManager : MonoBehaviour
         FactoryManager factoryManager,
         MachineWorkerManager machineWorkerManager,
         MachineSecurityManager machineSecurityManager,
+        SpawningWorkerManager spawningWorkerManager,
         IEnemiesSpawner enemiesSpawner)
     {
         foreach (var roomGO in roomInstances.Values)
         {
             var rm = roomGO.GetComponent<RoomManager>();
             if (rm != null)
-                rm.Initialize(factoryManager, machineWorkerManager, machineSecurityManager,enemiesSpawner);
+                rm.Initialize(factoryManager, machineWorkerManager, machineSecurityManager, spawningWorkerManager, enemiesSpawner);
         }
     }
 

--- a/Assets/Scripts/Robots/RobotRole.cs
+++ b/Assets/Scripts/Robots/RobotRole.cs
@@ -1,5 +1,6 @@
 public enum RobotRole
 {
     Worker,
-    SecurityGuard
+    SecurityGuard,
+    WorkerSpawner
 }

--- a/Assets/Scripts/Services/StationReservationService.cs
+++ b/Assets/Scripts/Services/StationReservationService.cs
@@ -30,6 +30,8 @@ public class StationReservationService : MonoBehaviour
         machine.OnRobotAssigned += HandleMachineOccupied;
         machine.OnPoweredOff += HandleMachinePoweredOff;
         machine.OnPoweredOn += HandleMachinePoweredOn;
+        if (!available.ContainsKey(role))
+            available[role] = new List<BaseMachine>();
         if (machine.IsOn && !machine.IsOccupied)
             available[role].Add(machine);
     }

--- a/Game.csproj
+++ b/Game.csproj
@@ -248,6 +248,8 @@
     <Compile Include="Assets\Scripts\Robots\JointBreaker.cs" />
     <Compile Include="Assets\Scripts\Map\LiftData.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IEnemiesSpawner.cs" />
+    <Compile Include="Assets\Scripts\Machines\SpawningWorkerManager.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToSpawningMachine.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\Scripts\Game.asmdef" />


### PR DESCRIPTION
## Summary
- add `WorkerSpawner` robot role
- handle new role in station reservations
- introduce `SpawningWorkerManager` and register spawning machines
- create `Worker_GoingToSpawningMachine` state
- mark worker spawners and update idle logic
- wire up managers in `FactoryManager`, `MapManager`, and `RoomManager`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `dotnet build Game.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876d9c680608324bb7d39bcb8b3adcf