### PR TITLE
Add Grab system edit mode tests

### DIFF
--- a/Assets/Tests/UnitTests/GrabHandAttractorTests.cs
+++ b/Assets/Tests/UnitTests/GrabHandAttractorTests.cs
@@ -1,0 +1,57 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class GrabHandAttractorTests
+{
+    private class DummyGrabbable : MonoBehaviour, IGrabbable
+    {
+        public bool CanBeGrabbed() => true;
+        public void OnGrab(Transform grabParent) {}
+        public void OnRelease(Vector2 throwForce) {}
+        public void OnAttract(Vector2 attractPoint) {}
+    }
+
+    [Test]
+    public void DetectGrabbable_DetectsObjectOnLayer()
+    {
+        var handObj = new GameObject("hand");
+        var attractor = handObj.AddComponent<GrabHandAttractor>();
+        attractor.detectionRadius = 1f;
+        int layer = 8;
+        attractor.detectionLayer = 1 << layer;
+
+        var obj = new GameObject("grabbable");
+        obj.layer = layer;
+        obj.transform.position = handObj.transform.position;
+        obj.AddComponent<CircleCollider2D>();
+        var grabbable = obj.AddComponent<DummyGrabbable>();
+
+        bool eventCalled = false;
+        attractor.OnObjectDetected += g => eventCalled = true;
+
+        var detected = attractor.DetectGrabbable();
+
+        Assert.AreEqual(grabbable, detected);
+        Assert.IsTrue(eventCalled);
+    }
+
+    [Test]
+    public void DetectGrabbable_IgnoresWrongLayer()
+    {
+        var handObj = new GameObject("hand");
+        var attractor = handObj.AddComponent<GrabHandAttractor>();
+        attractor.detectionRadius = 1f;
+        attractor.detectionLayer = 1 << 8;
+
+        var obj = new GameObject("grabbable");
+        obj.layer = 9;
+        obj.transform.position = handObj.transform.position;
+        obj.AddComponent<CircleCollider2D>();
+        obj.AddComponent<DummyGrabbable>();
+
+        var detected = attractor.DetectGrabbable();
+
+        Assert.IsNull(detected);
+    }
+}

--- a/Assets/Tests/UnitTests/GrabHandAttractorTests.cs.meta
+++ b/Assets/Tests/UnitTests/GrabHandAttractorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 56efd2b4-c92e-48f7-af91-c93f4ff54d58

--- a/Assets/Tests/UnitTests/GrabSystemTests.cs
+++ b/Assets/Tests/UnitTests/GrabSystemTests.cs
@@ -1,0 +1,82 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class GrabSystemTests
+{
+    private class DummyInput : MonoBehaviour, IPlayerInput
+    {
+        public Vector2 Movement => Vector2.zero;
+        public bool JumpPressed => false;
+        public bool PrimaryAttack => false;
+        public bool LeftGrabPressed;
+        public bool RightGrabPressed;
+    }
+
+    private class DummyGrabbable : MonoBehaviour, IGrabbable
+    {
+        public bool grabbed;
+        public bool released;
+        public Vector2 releasedForce;
+        public bool CanBeGrabbed() => true;
+        public void OnGrab(Transform grabParent)
+        {
+            grabbed = true;
+            transform.SetParent(grabParent);
+        }
+        public void OnRelease(Vector2 throwForce)
+        {
+            released = true;
+            releasedForce = throwForce;
+            transform.SetParent(null);
+        }
+        public void OnAttract(Vector2 attractPoint) {}
+    }
+
+    [Test]
+    public void GrabSystem_GrabAndReleaseObject()
+    {
+        // setup hand
+        var handObj = new GameObject("hand");
+        var attractor = handObj.AddComponent<GrabHandAttractor>();
+        attractor.detectionRadius = 1f;
+        int layer = 8;
+        attractor.detectionLayer = 1 << layer;
+
+        // object to grab
+        var obj = new GameObject("grab");
+        obj.layer = layer;
+        obj.AddComponent<CircleCollider2D>();
+        var grab = obj.AddComponent<DummyGrabbable>();
+        obj.transform.position = handObj.transform.position;
+
+        // grab system
+        var systemObj = new GameObject("system");
+        var system = systemObj.AddComponent<GrabSystem>();
+        system.leftHand = attractor;
+        system.throwStrength = 2f;
+        var inputObj = new GameObject("input");
+        var input = inputObj.AddComponent<DummyInput>();
+        typeof(GrabSystem).GetField("inputSource", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(system, input);
+        typeof(GrabSystem).GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(system, null);
+
+        var leftHeldField = typeof(GrabSystem).GetField("leftHeld", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        // grab
+        input.LeftGrabPressed = true;
+        system.Update();
+        input.LeftGrabPressed = false;
+        system.Update();
+
+        Assert.IsTrue(grab.grabbed);
+        Assert.AreEqual(grab, leftHeldField.GetValue(system));
+
+        // release
+        input.LeftGrabPressed = true;
+        system.Update();
+
+        Assert.IsTrue(grab.released);
+        Assert.AreEqual(Vector2.right * system.throwStrength, grab.releasedForce);
+        Assert.IsNull(leftHeldField.GetValue(system));
+    }
+}

--- a/Assets/Tests/UnitTests/GrabSystemTests.cs.meta
+++ b/Assets/Tests/UnitTests/GrabSystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 49f5f6ad-a641-4084-8bff-d94f25b19c96

--- a/Assets/Tests/UnitTests/PickupBoxTests.cs
+++ b/Assets/Tests/UnitTests/PickupBoxTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class PickupBoxTests
+{
+    [Test]
+    public void PickupBox_GrabAndReleaseAppliesVelocity()
+    {
+        var hand = new GameObject("hand").transform;
+        var obj = new GameObject("box");
+        var rb = obj.AddComponent<Rigidbody2D>();
+        var box = obj.AddComponent<PickupBox>();
+
+        box.OnGrab(hand);
+        Assert.IsTrue(rb.isKinematic);
+        Assert.AreEqual(hand, obj.transform.parent);
+
+        Vector2 force = new Vector2(3f, 2f);
+        box.OnRelease(force);
+
+        Assert.IsFalse(rb.isKinematic);
+        Assert.AreEqual(force, rb.velocity);
+        Assert.IsNull(obj.transform.parent);
+    }
+}

--- a/Assets/Tests/UnitTests/PickupBoxTests.cs.meta
+++ b/Assets/Tests/UnitTests/PickupBoxTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c68183f8-258c-4cc4-a2e7-52dffe1abe02

--- a/Assets/Tests/UnitTests/SecurityBadgePickupTests.cs
+++ b/Assets/Tests/UnitTests/SecurityBadgePickupTests.cs
@@ -1,0 +1,30 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class SecurityBadgePickupTests
+{
+    [Test]
+    public void Badge_AttachAndReleaseChangesPhysics()
+    {
+        var hand = new GameObject("hand").transform;
+        var obj = new GameObject("badge");
+        var rb = obj.AddComponent<Rigidbody2D>();
+        var badge = obj.AddComponent<SecurityBadgePickup>();
+
+        Assert.IsTrue(badge.CanBeGrabbed());
+        badge.OnGrab(hand);
+
+        Assert.IsFalse(rb.simulated);
+        Assert.AreEqual(Vector2.zero, rb.velocity);
+        Assert.AreEqual(hand, obj.transform.parent);
+        Assert.IsFalse(badge.CanBeGrabbed());
+
+        Vector2 throwForce = new Vector2(2f, 1f);
+        badge.OnRelease(throwForce);
+
+        Assert.IsTrue(rb.simulated);
+        Assert.AreEqual(throwForce, rb.velocity);
+        Assert.IsNull(obj.transform.parent);
+        Assert.IsTrue(badge.CanBeGrabbed());
+    }
+}

--- a/Assets/Tests/UnitTests/SecurityBadgePickupTests.cs.meta
+++ b/Assets/Tests/UnitTests/SecurityBadgePickupTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77da2257-e748-4a87-b121-c64ea98358ad


### PR DESCRIPTION
## Summary
- add tests for `GrabHandAttractor` detection logic
- add tests covering grab and release flow in `GrabSystem`
- verify SecurityBadgePickup and PickupBox grabbable behaviours

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b13fd6f88324b26af82fce1399e9