### PR TITLE
Add grid preview panel to HUD

### DIFF
--- a/Assets/UI Toolkit/GameHUDVisualTree.uxml
+++ b/Assets/UI Toolkit/GameHUDVisualTree.uxml
@@ -45,6 +45,10 @@
                     </Bindings>
                 </EnergyBar>
             </engine:VisualElement>
+            <engine:VisualElement class="minibackground">
+                <engine:VisualElement name="preview" class="grid-preview"
+                                      style="height: 142px; width: 250px; margin-top: 0;" />
+            </engine:VisualElement>
         </engine:VisualElement>
         <engine:VisualElement style="flex-grow: 1;" />
     </engine:VisualElement>


### PR DESCRIPTION
## Summary
- add mini background preview region after the energy/health bar in the HUD

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687949fba89083249fa72526c59e1b01