### PR TITLE
Fix mini map preview

### DIFF
--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -18,6 +18,8 @@ public class GameUIViewModel : MonoBehaviour
     {
         ui = GetComponent<UIDocument>().rootVisualElement;
 
+        miniMapPreview = ui.Q<VisualElement>("preview");
+
         hudMiniMap = GetComponentInChildren<HUDMiniMap>(true);
     }
 
@@ -68,10 +70,21 @@ public class GameUIViewModel : MonoBehaviour
 
     public void SetMiniMapTexture(RenderTexture rt)
     {
-        if (miniMapPreview != null && rt != null)
+        if (miniMapPreview == null || rt == null)
+            return;
+
+        var tex = new Texture2D(rt.width, rt.height, TextureFormat.RGBA32, false)
         {
-            miniMapPreview.style.backgroundImage = new StyleBackground(rt);
-            miniMapPreview.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
-        }
+            filterMode = FilterMode.Point
+        };
+
+        var prev = RenderTexture.active;
+        RenderTexture.active = rt;
+        tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+        tex.Apply();
+        RenderTexture.active = prev;
+
+        miniMapPreview.style.backgroundImage = new StyleBackground(tex);
+        miniMapPreview.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
     }
 }

--- a/Assets/Scripts/UI/HUDMiniMap.cs
+++ b/Assets/Scripts/UI/HUDMiniMap.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -65,8 +66,7 @@ public class HUDMiniMap : MonoBehaviour
 
         if (previewElement != null && miniMapRT != null)
         {
-            previewElement.style.backgroundImage = new StyleBackground(miniMapRT);
-            previewElement.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
+            StartCoroutine(CaptureRTToUI());
         }
     }
 
@@ -137,5 +137,24 @@ public class HUDMiniMap : MonoBehaviour
         PositionCamera();
         // Camera renders automatically to RenderTexture
 
+    }
+
+    private IEnumerator CaptureRTToUI()
+    {
+        yield return new WaitForEndOfFrame();
+
+        var tex = new Texture2D(miniMapRT.width, miniMapRT.height, TextureFormat.RGBA32, false)
+        {
+            filterMode = FilterMode.Point
+        };
+
+        var prev = RenderTexture.active;
+        RenderTexture.active = miniMapRT;
+        tex.ReadPixels(new Rect(0, 0, miniMapRT.width, miniMapRT.height), 0, 0);
+        tex.Apply();
+        RenderTexture.active = prev;
+
+        previewElement.style.backgroundImage = new StyleBackground(tex);
+        previewElement.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
     }
 }


### PR DESCRIPTION
## Summary
- initialize GameUIViewModel with preview UI element
- convert RenderTexture to Texture2D when assigning to HUD
- capture minimap texture once inside HUDMiniMap

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687953bbd8b883248f3feb74eca169b8