### PR TITLE
Spawn SecurityBadge from service

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -64,6 +64,13 @@ public class EnemyController : PhysicsBaseAgentController
         waypointNotifier.Subscribe(pathFollower);
         memory.SetRespawnService(respawnService);
         this.dropContainer = dropContainer;
+
+        if (SecurityBadgeSpawner.Instance != null)
+        {
+            if (initialBadge != null)
+                Destroy(initialBadge.gameObject);
+            initialBadge = SecurityBadgeSpawner.Instance.SpawnBadge(transform);
+        }
     }
 
     public void SetSecurityGuardState()

--- a/Assets/Scripts/Services/SecurityBadgeSpawner.cs
+++ b/Assets/Scripts/Services/SecurityBadgeSpawner.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class SecurityBadgeSpawner : MonoBehaviour
+{
+    public static SecurityBadgeSpawner Instance { get; private set; }
+
+    [SerializeField] private SecurityBadgePickup badgePrefab;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    public SecurityBadgePickup SpawnBadge(Transform parent)
+    {
+        if (badgePrefab == null) return null;
+        return Instantiate(badgePrefab, parent);
+    }
+}

--- a/Assets/Scripts/Services/SecurityBadgeSpawner.cs.meta
+++ b/Assets/Scripts/Services/SecurityBadgeSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae9b181e0aec495bbbc2e4d55e64f1dc

--- a/Assets/Scripts/Setup/SceneBootstrapConfigSO.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapConfigSO.cs
@@ -9,6 +9,7 @@ public class SceneBootstrapConfigSO : ScriptableObject
     public MapManager mapManagerPrefab;
     public WaypointService waypointServicePrefab;
     public RobotRespawnService respawnServicePrefab;
+    public SecurityBadgeSpawner badgeSpawnerPrefab;
     public SceneController sceneControllerPrefab;
     public GameUIViewModel gameUIViewModelPrefab;
     public VictorySetup victorySetupPrefab;

--- a/Assets/Scripts/Setup/SceneBootstrapper.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapper.cs
@@ -30,6 +30,7 @@ public class SceneBootstrapper : MonoBehaviour
         mapManager.Construct(gridBuilder, roomRenderer, roomProcessor);
         var waypointService = Instantiate(config.waypointServicePrefab);
         var respawnService = Instantiate(config.respawnServicePrefab);
+        var badgeSpawner = Instantiate(config.badgeSpawnerPrefab);
         if (SceneController.instance == null)
         {
             Instantiate(config.sceneControllerPrefab);

--- a/Game.csproj
+++ b/Game.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Assets\Scripts\EnemyAI\Core\RobotMemory.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Core\RobotRespawnService.cs" />
     <Compile Include="Assets\Scripts\Services\StationReservationService.cs" />
+    <Compile Include="Assets\Scripts\Services\SecurityBadgeSpawner.cs" />
     <Compile Include="Assets\Scripts\OBSOLETE\WarpMeshByVertexColor.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\EnemyState.cs" />
     <Compile Include="Assets\Scripts\Interfaces\ICellProcessor.cs" />


### PR DESCRIPTION
## Summary
- add `SecurityBadgeSpawner` service to instantiate badges
- load badge spawner prefab during scene bootstrap
- expose badge spawner prefab on scene config
- spawn a new badge during `EnemyController.Initialize`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795701b9488324b66cfc6cadce0bd5