### PR TITLE
Add contextual message system

### DIFF
--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -22,6 +22,13 @@ public class GameUIViewModel : MonoBehaviour
 
         previewVE = ui.Q<VisualElement>("miniMapPreview");
 
+        var service = MessageService.Instance;
+        if (service == null)
+        {
+            service = gameObject.AddComponent<MessageService>();
+        }
+        service.Initialize(ui);
+
         // hudMiniMap = GetComponentInChildren<HUDMiniMap>(true);
     }
 

--- a/Assets/Scripts/UI/MessageSystem/GameMessage.cs
+++ b/Assets/Scripts/UI/MessageSystem/GameMessage.cs
@@ -1,0 +1,18 @@
+using System;
+
+public struct GameMessage
+{
+    public string Text;
+    public MessageSpeaker Speaker;
+
+    public GameMessage(string text, MessageSpeaker speaker)
+    {
+        Text = text;
+        Speaker = speaker;
+    }
+
+    public override string ToString()
+    {
+        return Text;
+    }
+}

--- a/Assets/Scripts/UI/MessageSystem/GameMessages.cs
+++ b/Assets/Scripts/UI/MessageSystem/GameMessages.cs
@@ -1,0 +1,40 @@
+public static class GameMessages
+{
+    public static class Intro
+    {
+        public static GameMessage Welcome => new("Welcome to the factory. Stay hidden.", MessageSpeaker.DrHex);
+        public static GameMessage InstallModules => new("Install your first modules here.", MessageSpeaker.DrHex);
+        public static GameMessage FirstAttack => new("Try your punch on the test robot.", MessageSpeaker.DrHex);
+    }
+
+    public static class Room
+    {
+        public static GameMessage EnterNeutralRoom => new("This is a neutral room. Watch the robots.", MessageSpeaker.Player);
+        public static GameMessage EnterSecurityRoom => new("Security guards are here. Stay sharp.", MessageSpeaker.Player);
+        public static GameMessage ElevatorHint => new("This lift seems functional.", MessageSpeaker.DrHex);
+    }
+
+    public static class Alarm
+    {
+        public static GameMessage AlarmTriggered => new("Alert triggered. Hide or fight!", MessageSpeaker.DrHex);
+        public static GameMessage AlarmCleared => new("Alarm deactivated. Good job.", MessageSpeaker.DrHex);
+    }
+
+    public static class Combat
+    {
+        public static GameMessage LowEnergy => new("I'm losing energy...", MessageSpeaker.Player);
+        public static GameMessage EnemyDefeated => new("One down!", MessageSpeaker.Player);
+    }
+
+    public static class Lift
+    {
+        public static GameMessage GoingUp => new("Going up.", MessageSpeaker.DrHex);
+        public static GameMessage BlockedLift => new("Something's blocking the lift.", MessageSpeaker.Player);
+    }
+
+    public static class POI
+    {
+        public static GameMessage WorkstationFound => new("A workstation... could be useful.", MessageSpeaker.Player);
+        public static GameMessage RestZone => new("Looks like a rest zone for the bots.", MessageSpeaker.Player);
+    }
+}

--- a/Assets/Scripts/UI/MessageSystem/MessageService.cs
+++ b/Assets/Scripts/UI/MessageSystem/MessageService.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+public class MessageService : MonoBehaviour
+{
+    public static MessageService Instance { get; private set; }
+
+    private Label messageLabel;
+    private VisualElement root;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    public void Initialize(VisualElement rootElement)
+    {
+        root = rootElement;
+        messageLabel = root.Q<Label>("GameMessageLabel");
+    }
+
+    public void ShowMessage(GameMessage message, float duration = 3f)
+    {
+        if (messageLabel == null) return;
+
+        string speakerPrefix = message.Speaker switch
+        {
+            MessageSpeaker.DrHex => "Dr Hex: ",
+            MessageSpeaker.Player => "Me: ",
+            MessageSpeaker.Narrator => "",
+            _ => ""
+        };
+
+        messageLabel.text = speakerPrefix + message.Text;
+        messageLabel.style.display = DisplayStyle.Flex;
+
+        CancelInvoke(nameof(HideMessage));
+        Invoke(nameof(HideMessage), duration);
+    }
+
+    public void HideMessage()
+    {
+        if (messageLabel != null)
+            messageLabel.style.display = DisplayStyle.None;
+    }
+}

--- a/Assets/Scripts/UI/MessageSystem/MessageSpeaker.cs
+++ b/Assets/Scripts/UI/MessageSystem/MessageSpeaker.cs
@@ -1,0 +1,8 @@
+using System;
+
+public enum MessageSpeaker
+{
+    Narrator,
+    DrHex,
+    Player
+}

--- a/Assets/UI Toolkit/GameHUDVisualTree.uxml
+++ b/Assets/UI Toolkit/GameHUDVisualTree.uxml
@@ -52,5 +52,6 @@
         <engine:VisualElement style="flex-grow: 1; align-items: flex-start; justify-content: flex-end;">
             <engine:VisualElement name="miniMapPreview" class="grid-preview" style="height: 134px; width: 442px; margin-top: 0;" />
         </engine:VisualElement>
+        <engine:Label name="GameMessageLabel" style="position: absolute; bottom: 10px; left: 50%; transform: translateX(-50%); background-color: rgba(0,0,0,0.6); color: white; padding: 5px; unity-font-style: bold; display: none;" />
     </engine:VisualElement>
 </engine:UXML>


### PR DESCRIPTION
## Summary
- implement `MessageSpeaker` enumeration and `GameMessage` struct
- collect messages in new static `GameMessages` class
- add `MessageService` MonoBehaviour for showing HUD messages
- integrate the service with `GameUIViewModel`
- display messages via a new `GameMessageLabel` in the HUD

## Testing
- `unity -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68797ad894d48324a58fe8302c26192e