### PR TITLE
Improve WebGL persistence handling

### DIFF
--- a/Assets/Scripts/Player/Data/PlayerSaveService.cs
+++ b/Assets/Scripts/Player/Data/PlayerSaveService.cs
@@ -1,5 +1,10 @@
 using System.IO;
 using UnityEngine;
+
+// When running in WebGL builds, file writes occur in memory and are synced to
+// IndexedDB. The accompanying index.html enables
+// config.autoSyncPersistentDataPath for automatic persistence. If saving fails
+// on WebGL, consider falling back to PlayerPrefs or another storage solution.
 public class PlayerSaveService : MonoBehaviour, ISaveService
 {
     [SerializeField] private PlayerTemplate runtimePlayerData; // Assign in the Inspector
@@ -29,6 +34,7 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
 
         var json = JsonUtility.ToJson(CurrentSaveData);
         File.WriteAllText(saveFilePath, json);
+        // In WebGL builds the write happens in memory and is synced to IndexedDB.
         Debug.Log("Game saved at " + saveFilePath);
     }
 
@@ -43,7 +49,9 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
         }
         else
         {
-            // Initialize a new save data if no file exists
+            // Initialize a new save data if no file exists. On WebGL this may
+            // happen when the IndexedDB storage is empty. PlayerPrefs can be
+            // used as a fallback if file operations fail.
             CurrentSaveData = new SaveData();
             SaveGame();
             Debug.Log("New save data created and saved.");

--- a/PUBLISH_WEB/index.html
+++ b/PUBLISH_WEB/index.html
@@ -75,7 +75,7 @@
       // If you would like all file writes inside Unity Application.persistentDataPath
       // directory to automatically persist so that the contents are remembered when
       // the user revisits the site the next time, uncomment the following line:
-      // config.autoSyncPersistentDataPath = true;
+      config.autoSyncPersistentDataPath = true; // Persist saved files in WebGL builds
       // This autosyncing is currently not the default behavior to avoid regressing
       // existing user projects that might rely on the earlier manual
       // JS_FileSystem_Sync() behavior, but in future Unity version, this will be

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit
 ```
 
 The command will return a non‑zero exit code if any tests fail.
+
+### WebGL Persistent Data
+
+Saved files in WebGL builds reside in the browser's IndexedDB storage. The
+`PUBLISH_WEB/index.html` template sets `config.autoSyncPersistentDataPath = true`
+so writes to `Application.persistentDataPath` are automatically synchronized.
+If browser file operations fail, consider using `PlayerPrefs` or a custom
+JavaScript plugin.


### PR DESCRIPTION
## Summary
- enable `config.autoSyncPersistentDataPath` in the WebGL HTML template
- document how WebGL save data is synced
- mention IndexedDB syncing and PlayerPrefs fallback in `PlayerSaveService`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68878ec13bfc8324bf784bb795363e0e