### PR TITLE
Add level info to intro message

### DIFF
--- a/Assets/Scripts/Game/RunProgressManager.cs
+++ b/Assets/Scripts/Game/RunProgressManager.cs
@@ -13,6 +13,9 @@ public class RunProgressManager : MonoBehaviour
 
     private int currentLevelIndex = 1;
 
+    public int CurrentLevelIndex => currentLevelIndex;
+    public int LevelCount => mapConfigs != null ? mapConfigs.Count : 0;
+
     public RunMapConfigSO CurrentConfig
     {
         get

--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -33,7 +33,17 @@ public class GameUIViewModel : MonoBehaviour
     }
     private void Start()
     {
-        MessageService.Instance?.ShowMessage(GameMessages.System.Start);
+        var startMessage = GameMessages.System.Start;
+        string levelPrefix = string.Empty;
+
+        if (RunProgressManager.Instance != null)
+        {
+            int index = RunProgressManager.Instance.CurrentLevelIndex;
+            levelPrefix = index == 0 ? "Tutorial - Level 0: " : $"Level {index}: ";
+        }
+
+        var msg = new GameMessage(levelPrefix + startMessage.Text, startMessage.Speaker);
+        MessageService.Instance?.ShowMessage(msg);
     }
 
     public void SetPlayer(RobotStateController robot)


### PR DESCRIPTION
## Summary
- expose current level info in `RunProgressManager`
- prepend the level number to the starting message

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d6c17df883249d16dff227ff8467