### PR TITLE
Add tutorial message sequence

### DIFF
--- a/Assets/Scripts/FactoryCore/RoomManager.cs
+++ b/Assets/Scripts/FactoryCore/RoomManager.cs
@@ -11,6 +11,8 @@ public class RoomManager : MonoBehaviour
     public RoomProperties roomProperties;
 
     public event Action<AlarmState> OnRoomAlarmChanged;
+    public event Action<RoomManager> PlayerEntered;
+    public event Action<RoomManager> PlayerExited;
 
     [Header("Zone Detection")]
     public PositionTriggerZone triggerZone;
@@ -113,12 +115,12 @@ public class RoomManager : MonoBehaviour
 
     public void OnPlayerEnterRoom(Collider2D playerCollider)
     {
-        // Debug.Log($"{playerCollider.name} RoomManager: ENTER this room.");
+        PlayerEntered?.Invoke(this);
     }
 
     public void OnPlayerExitRoom()
     {
-        // Debug.Log($"{gameObject.name} RoomManager: EXIT this room.");
+        PlayerExited?.Invoke(this);
     }
 
     public Bounds GetRoomBounds()

--- a/Assets/Scripts/Game/TutorialManager.cs
+++ b/Assets/Scripts/Game/TutorialManager.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TutorialManager : MonoBehaviour
+{
+    private readonly List<GameMessage> messages = new()
+    {
+        GameMessages.Tutorial.Attack,
+        GameMessages.Tutorial.Interact,
+        GameMessages.Tutorial.SaveRobots,
+        GameMessages.Tutorial.Badges,
+        GameMessages.Tutorial.NextLevel
+    };
+
+    private int currentIndex = 0;
+    private HashSet<RoomManager> visitedRooms = new();
+    private readonly List<RoomManager> subscribedRooms = new();
+
+    private void Start()
+    {
+        if (RunProgressManager.Instance != null && RunProgressManager.Instance.CurrentLevelIndex == 0)
+        {
+            var rooms = FindObjectsOfType<RoomManager>();
+            foreach (var room in rooms)
+            {
+                room.PlayerEntered += HandlePlayerEnteredRoom;
+                subscribedRooms.Add(room);
+            }
+        }
+        else
+        {
+            enabled = false;
+        }
+    }
+
+    private void HandlePlayerEnteredRoom(RoomManager room)
+    {
+        if (!visitedRooms.Add(room)) return;
+
+        if (currentIndex < messages.Count)
+        {
+            MessageService.Instance?.ShowMessage(messages[currentIndex]);
+            currentIndex++;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        foreach (var room in subscribedRooms)
+        {
+            if (room != null)
+            {
+                room.PlayerEntered -= HandlePlayerEnteredRoom;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Setup/SceneBootstrapper.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapper.cs
@@ -53,5 +53,10 @@ public class SceneBootstrapper : MonoBehaviour
                 badgeSpawner
             );
         }
+
+        if (RunProgressManager.Instance != null && RunProgressManager.Instance.CurrentLevelIndex == 0)
+        {
+            new GameObject("TutorialManager").AddComponent<TutorialManager>();
+        }
     }
 }

--- a/Assets/Scripts/UI/MessageSystem/GameMessages.cs
+++ b/Assets/Scripts/UI/MessageSystem/GameMessages.cs
@@ -7,6 +7,15 @@ public static class GameMessages
         public static GameMessage FirstAttack => new("Try your punch on the test robot.", MessageSpeaker.DrHex);
     }
 
+    public static class Tutorial
+    {
+        public static GameMessage Attack => new("Left click to attack enemies.", MessageSpeaker.Narrator);
+        public static GameMessage Interact => new("Right click to interact with objects and robots.", MessageSpeaker.Narrator);
+        public static GameMessage SaveRobots => new("Save robots — saving all of them opens all the doors.", MessageSpeaker.Narrator);
+        public static GameMessage Badges => new("Defeat security robots — they drop badges that unlock restricted doors.", MessageSpeaker.Narrator);
+        public static GameMessage NextLevel => new("Enter the final door in the last room to reach the next level.", MessageSpeaker.Narrator);
+    }
+
     public static class Room
     {
         public static GameMessage EnterNeutralRoom => new("This is a neutral room. Watch the robots.", MessageSpeaker.Player);

--- a/Game.csproj
+++ b/Game.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Assets\Scripts\Navigation\PriorityQueue.cs" />
     <Compile Include="Assets\Scripts\Map\WaypointService.cs" />
     <Compile Include="Assets\Scripts\Game\TargetAim.cs" />
+    <Compile Include="Assets\Scripts\Game\TutorialManager.cs" />
     <Compile Include="Assets\Scripts\Robots\EnergyBot.cs" />
     <Compile Include="Assets\Scripts\Navigation\RunMapConfigSO.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IPlayerSpawner.cs" />


### PR DESCRIPTION
## Summary
- introduce `TutorialManager` to show a sequence of tutorial messages
- expose player entry/exit events from `RoomManager`
- define tutorial messages in `GameMessages`
- spawn `TutorialManager` when bootstrapper detects tutorial level
- compile new script in the main `Game.csproj`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e028b5bc8324a97a17888ec031b4