### PR TITLE
Fix PickupBoxTests for new Rigidbody2D API

### DIFF
--- a/Assets/Editor/UnitTests/PickupBoxTests.cs
+++ b/Assets/Editor/UnitTests/PickupBoxTests.cs
@@ -12,13 +12,13 @@ public class PickupBoxTests
         var box = obj.AddComponent<PickupBox>();
 
         box.OnGrab(hand);
-        Assert.IsTrue(rb.isKinematic);
+        Assert.AreEqual(RigidbodyType2D.Kinematic, rb.bodyType);
         Assert.AreEqual(hand, obj.transform.parent);
 
         Vector2 force = new Vector2(3f, 2f);
         box.OnRelease(force);
 
-        Assert.IsFalse(rb.isKinematic);
+        Assert.AreEqual(RigidbodyType2D.Dynamic, rb.bodyType);
         Assert.AreEqual(force, rb.linearVelocity);
         Assert.IsNull(obj.transform.parent);
     }


### PR DESCRIPTION
## Summary
- update PickupBox unit test to use Rigidbody2D.bodyType

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888539682208324af30836ecec7c4c4