### PR TITLE
Fix CS0618 with FindObjectsByType

### DIFF
--- a/Assets/Scripts/Game/TutorialManager.cs
+++ b/Assets/Scripts/Game/TutorialManager.cs
@@ -20,7 +20,7 @@ public class TutorialManager : MonoBehaviour
     {
         if (RunProgressManager.Instance != null && RunProgressManager.Instance.CurrentLevelIndex == 0)
         {
-            var rooms = FindObjectsOfType<RoomManager>();
+            var rooms = FindObjectsByType<RoomManager>(FindObjectsSortMode.None);
             foreach (var room in rooms)
             {
                 room.PlayerEntered += HandlePlayerEnteredRoom;


### PR DESCRIPTION
## Summary
- replace deprecated `FindObjectsOfType` with `FindObjectsByType` in `TutorialManager`

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*
- `msbuild Game.csproj -version` *(fails: command not found)*
- `unity-editor --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888553347a0832494d41ca928f78082