### PR TITLE
Fix deprecated API usage

### DIFF
--- a/Assets/Scripts/Game/TutorialManager.cs
+++ b/Assets/Scripts/Game/TutorialManager.cs
@@ -20,7 +20,7 @@ public class TutorialManager : MonoBehaviour
     {
         if (RunProgressManager.Instance != null && RunProgressManager.Instance.CurrentLevelIndex == 1)
         {
-            var rooms = FindObjectsByType<RoomManager>(FindObjectsSortMode.None);
+            var rooms = FindObjectsOfType<RoomManager>();
             foreach (var room in rooms)
             {
                 room.PlayerEntered += HandlePlayerEnteredRoom;


### PR DESCRIPTION
## Summary
- replace deprecated `FindObjectsByType` with `FindObjectsOfType`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688866c5dc28832480721e885a4bd71a