### PR TITLE
Handle null in path finder

### DIFF
--- a/Assets/Editor/UnitTests/WaypointPathFinderTests.cs
+++ b/Assets/Editor/UnitTests/WaypointPathFinderTests.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Collections.Generic;
+
+public class WaypointPathFinderTests
+{
+    [Test]
+    public void FindWorldPath_NullWaypoint_ReturnsEmpty()
+    {
+        var go = new GameObject();
+        var finder = go.AddComponent<WaypointPathFinder>();
+
+        List<RoomWaypoint> result = null;
+        Assert.DoesNotThrow(() => result = finder.FindWorldPath(null, null));
+        Assert.IsNotNull(result);
+        Assert.IsEmpty(result);
+    }
+}

--- a/Assets/Editor/UnitTests/WaypointPathFinderTests.cs.meta
+++ b/Assets/Editor/UnitTests/WaypointPathFinderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba242b106dc340fa9d1c08d697c71fa1

--- a/Assets/Scripts/Map/WaypointPathFinder.cs
+++ b/Assets/Scripts/Map/WaypointPathFinder.cs
@@ -23,13 +23,19 @@ public class WaypointPathFinder : MonoBehaviour, IPathFinder
 
     public List<RoomWaypoint> FindWorldPath(RoomWaypoint start, RoomWaypoint end)
     {
+        if (start == null || end == null)
+        {
+            Debug.LogWarning("FindWorldPath called with a null waypoint.");
+            return new List<RoomWaypoint>();
+        }
+
         var queue = new Queue<RoomWaypoint>();
         var cameFrom = new Dictionary<RoomWaypoint, RoomWaypoint>();
         var visited = new HashSet<RoomWaypoint>();
 
         queue.Enqueue(start);
         visited.Add(start);
-        cameFrom[start] = null; //TODO ArgumentNullException: Value cannot be null.
+        cameFrom[start] = null;
 
         while (queue.Count > 0)
         {


### PR DESCRIPTION
## Summary
- guard against null start or end waypoint in `FindWorldPath`
- add unit test covering null pathfinding case

## Testing
- `bash setup_env.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68887a8747088324a5b5a6e2aff5d179