### PR TITLE
Add object pooling and tests

### DIFF
--- a/Assets/Editor/UnitTests/ObjectPoolTests.cs
+++ b/Assets/Editor/UnitTests/ObjectPoolTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class ObjectPoolTests
+{
+    [Test]
+    public void GetAndRelease_ReusesInstance()
+    {
+        var poolGO = new GameObject("Pool");
+        var pool = poolGO.AddComponent<ObjectPool>();
+        var prefab = new GameObject("prefab");
+
+        var first = pool.Get(prefab, pool.transform);
+        pool.Release(first);
+        var second = pool.Get(prefab, pool.transform);
+
+        Assert.AreSame(first, second);
+    }
+}

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -142,7 +142,7 @@ public class EnemyController : PhysicsBaseAgentController
     private IEnumerator DieRoutine()
     {
         yield return new WaitForSeconds(10f);
-        Destroy(gameObject);
+        ObjectPool.Instance.Release(gameObject);
     }
 
     private void DetachHeldBadges()

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -114,7 +114,7 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     private IEnumerator DieRoutine()
     {
         yield return new WaitForSeconds(5f);
-        Destroy(gameObject);
+        ObjectPool.Instance.Release(gameObject);
     }
 
     private void DisableAnimator()

--- a/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
+++ b/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
@@ -53,8 +53,8 @@ public class RobotMemory : MonoBehaviour, IRobotMemory
             Debug.LogError("[EnemyMemory] Cannot respawn: service is null!");
         }
 
-        // Finally, destroy the stuck enemy’s GameObject:
-        Destroy(controller.gameObject);
+        // Finally, return the stuck enemy to the pool:
+        ObjectPool.Instance.Release(controller.gameObject);
     }
 
     /// <summary>
@@ -74,8 +74,8 @@ public class RobotMemory : MonoBehaviour, IRobotMemory
             Debug.LogError("[EnemyMemory] Cannot respawn: service is null!");
         }
 
-        // Finally, destroy the stuck enemy’s GameObject:
-        Destroy(controller.gameObject);
+        // Finally, return the stuck boss to the pool:
+        ObjectPool.Instance.Release(controller.gameObject);
     }
 
     /// <summary>

--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -56,10 +56,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         spawnedWorkers.Clear();
         for (int i = 0; i < workersToSpawn; i++)
         {
-            var worker = Instantiate(workerPrefab,
-                Vector3.zero,
-                Quaternion.identity,
-                enemiesParent);
+            var worker = ObjectPool.Instance.Get(workerPrefab, enemiesParent);
             var robotState = worker.GetComponent<RobotStateController>();
             robotState.Stats = workerRobotFactory.CreateRobot();
             robotState.Stats.RobotName = $"Worker {i + 1}";
@@ -76,10 +73,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         spawnedEnemies.Clear();
         for (int i = 0; i < enemiesToSpawn; i++)
         {
-            var enemy = Instantiate(enemyPrefab,
-                Vector3.zero,
-                Quaternion.identity,
-                enemiesParent);
+            var enemy = ObjectPool.Instance.Get(enemyPrefab, enemiesParent);
 
             var robotState = enemy.GetComponent<RobotStateController>();
             robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -93,11 +87,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
     {
         EnemyRobotFactory enemyRobotFactory = new EnemyRobotFactory();
 
-        boosInstance = Instantiate(
-            bossPrefab,
-            Vector3.zero,
-            Quaternion.identity,
-            enemiesParent);
+        boosInstance = ObjectPool.Instance.Get(bossPrefab, enemiesParent);
 
         var robotState = this.boosInstance.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -249,8 +239,8 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
     /// </summary>
     public void SpawnEnemyAtRandom()
     {
-        // 1) Create a fresh GameObject (no pooling; pure new instance).
-        GameObject workerGO = Instantiate(workerPrefab, Vector3.zero, Quaternion.identity, enemiesParent);
+        // 1) Grab a worker from the pool.
+        GameObject workerGO = ObjectPool.Instance.Get(workerPrefab, enemiesParent);
         SpawnInstanceAtRandom(workerGO);
     }
     public void SpawnBossAtRandom()

--- a/Assets/Scripts/Managers/ObjectPool.cs
+++ b/Assets/Scripts/Managers/ObjectPool.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using UnityEngine;
+using JoostenProductions;
+
+/// <summary>
+/// Simple singleton-based object pool for GameObjects.
+/// Objects are returned inactive when released and reused on the next request.
+/// </summary>
+public class ObjectPool : SingletonBehaviour<ObjectPool>
+{
+    // Persist across scenes so pooled objects survive reloads
+    protected override bool DoNotDestroyOnLoad => true;
+
+    private readonly Dictionary<GameObject, Queue<GameObject>> pools = new();
+    private readonly Dictionary<GameObject, GameObject> instanceToPrefab = new();
+
+    /// <summary>
+    /// Get an instance for the given prefab. The returned object is inactive.
+    /// </summary>
+    public GameObject Get(GameObject prefab, Transform parent)
+    {
+        if (!pools.TryGetValue(prefab, out var queue))
+        {
+            queue = new Queue<GameObject>();
+            pools[prefab] = queue;
+        }
+
+        GameObject obj = queue.Count > 0 ? queue.Dequeue() : Instantiate(prefab);
+        instanceToPrefab[obj] = prefab;
+        obj.transform.SetParent(parent, false);
+        obj.SetActive(false);
+        return obj;
+    }
+
+    /// <summary>
+    /// Return an instance to the pool.
+    /// </summary>
+    public void Release(GameObject obj)
+    {
+        if (obj == null) return;
+        obj.SetActive(false);
+        obj.transform.SetParent(transform, false);
+
+        if (instanceToPrefab.TryGetValue(obj, out var prefab) && pools.TryGetValue(prefab, out var queue))
+        {
+            queue.Enqueue(obj);
+        }
+        else
+        {
+            Destroy(obj);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple singleton `ObjectPool` for GameObjects
- use the pool in `EnemiesSpawner` when creating or spawning robots
- return robots to the pool instead of destroying them
- add unit test covering pool reuse

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887aad90208324ab83e189da2bcba8