### PR TITLE
Integrate Input System actions

### DIFF
--- a/Assets/Editor/UnitTests/GrabSystemTests.cs
+++ b/Assets/Editor/UnitTests/GrabSystemTests.cs
@@ -10,20 +10,31 @@ public class GrabSystemTests
         public bool JumpPressed => false;
         public bool PrimaryAttack => false;
 
-        public bool LeftGrabDown => throw new System.NotImplementedException();
+        public bool LeftGrabDown  { get; private set; }
+        public bool LeftGrabHeld  { get; private set; }
+        public bool LeftGrabUp    { get; private set; }
 
-        public bool LeftGrabHeld => throw new System.NotImplementedException();
+        public bool RightGrabDown => LeftGrabDown;
+        public bool RightGrabHeld => LeftGrabHeld;
+        public bool RightGrabUp   => LeftGrabUp;
 
-        public bool LeftGrabUp => throw new System.NotImplementedException();
+        public void PressGrab()
+        {
+            LeftGrabDown = true;
+            LeftGrabHeld = true;
+        }
 
-        public bool RightGrabDown => throw new System.NotImplementedException();
+        public void ReleaseGrab()
+        {
+            LeftGrabHeld = false;
+            LeftGrabUp = true;
+        }
 
-        public bool RightGrabHeld => throw new System.NotImplementedException();
-
-        public bool RightGrabUp => throw new System.NotImplementedException();
-
-        public bool LeftGrabPressed;
-        public bool RightGrabPressed;
+        public void NextFrame()
+        {
+            LeftGrabDown = false;
+            LeftGrabUp = false;
+        }
     }
 
     private class DummyGrabbable : MonoBehaviour, IGrabbable
@@ -76,17 +87,17 @@ public class GrabSystemTests
         var leftHeldField = typeof(GrabSystem).GetField("leftHeld", BindingFlags.NonPublic | BindingFlags.Instance);
 
         // grab
-        input.LeftGrabPressed = true;
-        // system.Update();
-        input.LeftGrabPressed = false;
-        // system.Update();
+        input.PressGrab();
+        system.Update();
+        input.NextFrame();
 
         Assert.IsTrue(grab.grabbed);
         Assert.AreEqual(grab, leftHeldField.GetValue(system));
 
         // release
-        input.LeftGrabPressed = true;
-        // system.Update();
+        input.ReleaseGrab();
+        system.Update();
+        input.NextFrame();
 
         Assert.IsTrue(grab.released);
         Assert.AreEqual(Vector2.right * system.throwStrength, grab.releasedForce);

--- a/Assets/Scripts/InputSystem_Actions.cs
+++ b/Assets/Scripts/InputSystem_Actions.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InputSystem_Actions
+{
+    public InputActionAsset asset { get; }
+    public InputActionMap Player { get; }
+    public InputAction Move { get; }
+    public InputAction Jump { get; }
+    public InputAction Attack { get; }
+    public InputAction Interact { get; }
+
+    public InputSystem_Actions()
+    {
+        asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        Player = new InputActionMap("Player");
+
+        Move = Player.AddAction("Move", InputActionType.Value);
+        Jump = Player.AddAction("Jump", InputActionType.Button);
+        Attack = Player.AddAction("Attack", InputActionType.Button);
+        Interact = Player.AddAction("Interact", InputActionType.Button);
+
+        asset.AddActionMap(Player);
+    }
+
+    public void Enable() => asset.Enable();
+    public void Disable() => asset.Disable();
+}

--- a/Assets/Scripts/Player/Controllers/PlayerInputReader.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerInputReader.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public class PlayerInputReader : MonoBehaviour, IPlayerInput
 {
@@ -14,20 +15,36 @@ public class PlayerInputReader : MonoBehaviour, IPlayerInput
     public bool RightGrabHeld { get; private set; }
     public bool RightGrabUp   { get; private set; }
 
-    void Update()
+    private InputSystem_Actions controls;
+
+    private void Awake()
     {
-        Movement      = new Vector2(Input.GetAxis("Horizontal"), Input.GetAxis("Vertical"));
-        JumpPressed   = Input.GetButton("Jump");
-        PrimaryAttack = Input.GetMouseButton(0);
+        controls = new InputSystem_Actions();
 
-        // Left grab on RMB:
-        LeftGrabDown  = Input.GetMouseButtonDown(1);
-        LeftGrabHeld  = Input.GetMouseButton   (1);
-        LeftGrabUp    = Input.GetMouseButtonUp  (1);
+        controls.Player.Move.performed += ctx => Movement = ctx.ReadValue<Vector2>();
+        controls.Player.Jump.started += ctx => JumpPressed = true;
+        controls.Player.Jump.canceled += ctx => JumpPressed = false;
+        controls.Player.Attack.started += ctx => PrimaryAttack = true;
+        controls.Player.Attack.canceled += ctx => PrimaryAttack = false;
 
-        // Right grab—if you really want the same button, map it too.
-        RightGrabDown = LeftGrabDown;
-        RightGrabHeld = LeftGrabHeld;
-        RightGrabUp   = LeftGrabUp;
+        controls.Player.Interact.started += ctx =>
+        {
+            LeftGrabDown = RightGrabDown = true;
+            LeftGrabHeld = RightGrabHeld = true;
+        };
+        controls.Player.Interact.canceled += ctx =>
+        {
+            LeftGrabHeld = RightGrabHeld = false;
+            LeftGrabUp = RightGrabUp = true;
+        };
+    }
+
+    private void OnEnable() => controls.Enable();
+    private void OnDisable() => controls.Disable();
+
+    private void LateUpdate()
+    {
+        LeftGrabDown = RightGrabDown = false;
+        LeftGrabUp = RightGrabUp = false;
     }
 }


### PR DESCRIPTION
## Summary
- add lightweight `InputSystem_Actions` wrapper
- use the new input system in `PlayerInputReader`
- update grab system test to work with InputAction based input

## Testing
- `dotnet test UnitTests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887abb9cc88324b159fce978da78b5