### PR TITLE
Add XML summaries for key classes

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -2,6 +2,11 @@ using UnityEngine;
 using System.Collections;
 
 [RequireComponent(typeof(EnemyStateMachine), typeof(RobotMemory))]
+/// <summary>
+/// Controls enemy behaviour and state transitions. Initializes path following
+/// and badge spawning services and provides APIs to change state or assign
+/// destinations.
+/// </summary>
 public class EnemyController : PhysicsBaseAgentController
 {
     [SerializeField] private EnemyStateMachine stateMachine;

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
@@ -1,6 +1,10 @@
 using System.Collections;
 using UnityEngine;
 
+/// <summary>
+/// Handles the punching animation for enemies. Uses configured arm targets and
+/// hitboxes to strike the player when they enter the attack zone.
+/// </summary>
 public class EnemyPunchAttack : MonoBehaviour
 {
     [SerializeField] private FollowPlayerTriggerHandler targetToFollow; // assigned via inspector

--- a/Assets/Scripts/EnemyAI/Core/RobotRespawnService.cs
+++ b/Assets/Scripts/EnemyAI/Core/RobotRespawnService.cs
@@ -1,5 +1,9 @@
 using UnityEngine;
 
+/// <summary>
+/// Service used by enemies to respawn new robots via the <see cref="EnemiesSpawner"/>.
+/// Offers methods to spawn either workers or bosses.
+/// </summary>
 public class RobotRespawnService : MonoBehaviour, IRobotRespawnService
 {
     private EnemiesSpawner spawner;

--- a/Assets/Scripts/FactoryCore/FactoryManager.cs
+++ b/Assets/Scripts/FactoryCore/FactoryManager.cs
@@ -3,6 +3,10 @@ using System;
 using UnityEngine.SceneManagement;
 using System.Linq;
 
+/// <summary>
+/// Coordinates initialization of the factory map and machines. Tracks alarm
+/// state changes and exposes events when the factory enters a new alarm level.
+/// </summary>
 public class FactoryManager : MonoBehaviour, IFactoryManager
 {
     [SerializeField] public FactoryAlarmStatus factoryAlarmStatus;

--- a/Assets/Scripts/Game/BulletScript.cs
+++ b/Assets/Scripts/Game/BulletScript.cs
@@ -1,5 +1,9 @@
 using UnityEngine;
 
+/// <summary>
+/// Simple projectile that launches toward the mouse position and destroys
+/// itself after a short lifetime.
+/// </summary>
 public class BulletScript : MonoBehaviour
 {
     private Vector3 mousePos;

--- a/Assets/Scripts/Services/SecurityBadgeSpawner.cs
+++ b/Assets/Scripts/Services/SecurityBadgeSpawner.cs
@@ -1,5 +1,9 @@
 using UnityEngine;
 
+/// <summary>
+/// Creates security badge pickups and attaches them to a specified parent with
+/// spring joint physics.
+/// </summary>
 public class SecurityBadgeSpawner : MonoBehaviour
 {
     [SerializeField] private SecurityBadgePickup badgePrefab;

--- a/Assets/Scripts/Services/StationReservationService.cs
+++ b/Assets/Scripts/Services/StationReservationService.cs
@@ -2,6 +2,10 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// Manages which machines are available for workers. Raises events when a
+/// machine is powered on, off or freed so robots can reserve stations.
+/// </summary>
 public class StationReservationService : MonoBehaviour
 {
     public static StationReservationService Instance { get; private set; }


### PR DESCRIPTION
## Summary
- add XML summary for `EnemyController`
- add XML summary for `EnemyPunchAttack`
- add XML summary for `RobotRespawnService`
- add XML summary for `FactoryManager`
- add XML summary for `SecurityBadgeSpawner`
- add XML summary for `StationReservationService`
- add XML summary for `BulletScript`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887aceb870832483b7c4484d10109f