### PR TITLE
Fix badge attachment

### DIFF
--- a/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
@@ -150,6 +150,9 @@ public class PlayerMovementController : MonoBehaviour
 
     public void Die()
     {
+        // Drop any badge the player is carrying
+        SecurityBadgePickup.DropPlayerBadge();
+
         var jointBreaker = GetComponent<JointBreaker>();
         jointBreaker?.BreakAll();
     }

--- a/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
+++ b/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
@@ -63,7 +63,16 @@ public class GrabSystem : MonoBehaviour
         if (obj != null && obj.CanBeGrabbed())
         {
             obj.OnGrab(hand.transform);
-            held = obj;
+
+            // Badges attach to the player's body and should not remain in hand
+            if (obj is SecurityBadgePickup)
+            {
+                held = null;
+            }
+            else
+            {
+                held = obj;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- attach security badges to the player's hips when grabbed
- keep only one badge by destroying all others after pickup
- prevent throwing the badge and drop it when the player dies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688887a192108324b8cb98ccfc6ab355