### PR TITLE
Replace SpringJoint2D with TargetJoint2D

### DIFF
--- a/Assets/Editor/UnitTests/SecurityBadgePickupTests.cs
+++ b/Assets/Editor/UnitTests/SecurityBadgePickupTests.cs
@@ -14,17 +14,15 @@ public class SecurityBadgePickupTests
         Assert.IsTrue(badge.CanBeGrabbed());
         badge.OnGrab(hand);
 
-        Assert.IsFalse(rb.simulated);
-        Assert.AreEqual(Vector2.zero, rb.linearVelocity);
-        Assert.AreEqual(hand, obj.transform.parent);
+        var joint = obj.GetComponent<TargetJoint2D>();
+        Assert.IsTrue(joint.enabled);
+        Assert.AreEqual((Vector2)hand.position, joint.target);
         Assert.IsFalse(badge.CanBeGrabbed());
 
         Vector2 throwForce = new Vector2(2f, 1f);
         badge.OnRelease(throwForce);
 
-        Assert.IsTrue(rb.simulated);
-        Assert.AreEqual(throwForce, rb.linearVelocity);
-        Assert.IsNull(obj.transform.parent);
+        Assert.IsFalse(joint.enabled);
         Assert.IsTrue(badge.CanBeGrabbed());
     }
 }

--- a/Assets/Scripts/Services/SecurityBadgeSpawner.cs
+++ b/Assets/Scripts/Services/SecurityBadgeSpawner.cs
@@ -2,13 +2,13 @@ using UnityEngine;
 
 /// <summary>
 /// Creates security badge pickups and attaches them to a specified parent with
-/// spring joint physics.
+/// target joint physics.
 /// </summary>
 public class SecurityBadgeSpawner : MonoBehaviour
 {
     [SerializeField] private SecurityBadgePickup badgePrefab;
 
-    [Header("Spring Joint Settings")]
+    [Header("Target Joint Settings")]
     [Tooltip("How springy the joint is.")]
     [SerializeField] private float frequency = 5f;
     [Tooltip("How much the joint resists oscillation.")]
@@ -32,7 +32,7 @@ public class SecurityBadgeSpawner : MonoBehaviour
             parent
         );
 
-        // 2) Ensure both badge and parent have Rigidbody2D
+        // 2) Ensure the badge has a Rigidbody2D
         var badgeRb = badge.GetComponent<Rigidbody2D>();
         if (badgeRb == null)
         {
@@ -40,24 +40,16 @@ public class SecurityBadgeSpawner : MonoBehaviour
             return badge;
         }
 
-        var parentRb = parent.GetComponent<Rigidbody2D>();
-        if (parentRb == null)
-        {
-            Debug.LogError($"SecurityBadgeSpawner: Parent '{parent.name}' has no Rigidbody2D.");
-            return badge;
-        }
+        // 3) Add and configure a TargetJoint2D on the badge
+        var joint = badge.gameObject.AddComponent<TargetJoint2D>();
+        joint.autoConfigureTarget = false;
+        joint.target = parent.position;
+        joint.frequency = frequency;          // spring strength
+        joint.dampingRatio = dampingRatio;    // damping
+        joint.maxForce = maxForce;
 
-        // 3) Add and configure a SpringJoint2D on the badge
-        var spring = badge.gameObject.AddComponent<SpringJoint2D>();
-        spring.connectedBody = parentRb;
-        spring.autoConfigureDistance = false;
-        spring.distance = 0f;                  // keep them exactly together
-        spring.frequency = frequency;          // spring strength
-        spring.dampingRatio = dampingRatio;    // damping
-        spring.enableCollision = false;        // badge won't collide back into parent
-
-        // Unfortunately SpringJoint2D has no maxForce setting,
-        // so if you need that you could clamp badgeRb.velocity in Update()
+        // Make the badge follow the parent transform
+        badge.SetFollowTarget(parent);
 
         return badge;
     }


### PR DESCRIPTION
## Summary
- use `TargetJoint2D` instead of `SpringJoint2D` for the badge
- add `SetFollowTarget` helper for following a transform
- adjust the security badge spawner to configure the new joint
- update editor tests to match new behaviour

## Testing
- `dotnet test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68888d6d1fe083249592949b5dc4acca