### PR TITLE
Implement movement reset on key release

### DIFF
--- a/Assets/Scripts/Player/Controllers/PlayerInputReader.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerInputReader.cs
@@ -22,6 +22,7 @@ public class PlayerInputReader : MonoBehaviour, IPlayerInput
         controls = new InputSystem_Actions();
 
         controls.Player.Move.performed += ctx => Movement = ctx.ReadValue<Vector2>();
+        controls.Player.Move.canceled += ctx => Movement = Vector2.zero;
         controls.Player.Jump.started += ctx => JumpPressed = true;
         controls.Player.Jump.canceled += ctx => JumpPressed = false;
         controls.Player.Attack.started += ctx => PrimaryAttack = true;


### PR DESCRIPTION
## Summary
- update PlayerInputReader to clear Movement when Move input is cancelled

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688930aabe108324a1f2fbbfdc8493f4