### PR TITLE
Implement security guard AI logic

### DIFF
--- a/Assets/Editor/UnitTests/SecurityMachineTests.cs
+++ b/Assets/Editor/UnitTests/SecurityMachineTests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class SecurityMachineTests
+{
+    private GameObject _machineGO;
+    private SecurityMachine _machine;
+    private EnemyController _guard;
+    private EnemyStateMachine _stateMachine;
+    private WaypointService _waypointService;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _machineGO = new GameObject();
+        _machine = _machineGO.AddComponent<SecurityMachine>();
+        _waypointService = _machineGO.AddComponent<WaypointService>();
+        _machine.InitializeWaypointService(_waypointService);
+
+        var guardGO = new GameObject();
+        _guard = guardGO.AddComponent<EnemyController>();
+        _stateMachine = guardGO.AddComponent<EnemyStateMachine>();
+        _guard.EnemyStatus = EnemyStatus.Idle;
+    }
+
+    [Test]
+    public void PowerOff_SendsGuardToRest()
+    {
+        _machine.AttachRobot(_guard.gameObject);
+        _machine.PowerOff();
+        Assert.AreEqual(EnemyStatus.GoingToRest, _guard.EnemyStatus);
+    }
+}

--- a/Assets/Scripts/EnemyAI/Controllers/ReactiveMachineAI.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/ReactiveMachineAI.cs
@@ -45,5 +45,14 @@ public class ReactiveMachineAI : MonoBehaviour
         stateMachine.ChangeState(new Enemy_ReactiveRestingMachine(
             controller, stateMachine, waypointService, machine, returnPoint));
     }
+
+    public void ReactivateSecurityMachine(SecurityMachine machine)
+    {
+        if (controller == null || stateMachine == null || waypointService == null)
+            return;
+        var returnPoint = controller.memory.LastVisitedPoint;
+        stateMachine.ChangeState(new Enemy_ReactivateSecurityMachine(
+            controller, stateMachine, waypointService, machine, returnPoint));
+    }
 }
 

--- a/Assets/Scripts/EnemyAI/States/Enemy_CheckingSecurity.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_CheckingSecurity.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class Enemy_CheckingSecurity : EnemyState
+{
+    public Enemy_CheckingSecurity(EnemyController enemy, EnemyStateMachine stateMachine, IWaypointService waypointService)
+        : base(enemy, stateMachine, waypointService) {}
+
+    public override void EnterState()
+    {
+        enemy.EnemyStatus = EnemyStatus.CheckingSecurity;
+        enemy.SetMovement(0f);
+        enemy.SetVerticalMovement(0f);
+    }
+
+    public override void UpdateState()
+    {
+        if (enemy.memory.LastKnownPlayerPosition != Vector3.zero && enemy.memory.WasRecentlyAttacked)
+        {
+            stateMachine.ChangeState(new Enemy_AttackPlayer(enemy, stateMachine, waypointService, this));
+        }
+    }
+
+    public override void ExitState() { }
+}

--- a/Assets/Scripts/EnemyAI/States/Enemy_GoingToRest.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_GoingToRest.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class Enemy_GoingToRest : EnemyState
+{
+    private RoomWaypoint targetPoint;
+    private bool hasArrived;
+
+    public Enemy_GoingToRest(EnemyController enemy, EnemyStateMachine machine, IWaypointService waypointService)
+        : base(enemy, machine, waypointService) { }
+
+    public override void EnterState()
+    {
+        enemy.EnemyStatus = EnemyStatus.GoingToRest;
+        targetPoint = waypointService.GetFirstRestPoint(enemy.memory.LastVisitedPoint);
+        if (targetPoint == null)
+            targetPoint = waypointService.GetFirstRestPoint();
+        if (targetPoint == null)
+        {
+            stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
+            return;
+        }
+        enemy.SetDestination(targetPoint);
+        hasArrived = false;
+    }
+
+    public override void UpdateState()
+    {
+        if (hasArrived) return;
+        if (enemy.HasArrivedAtDestination())
+        {
+            hasArrived = true;
+            enemy.SetMovement(0f);
+            enemy.SetVerticalMovement(0f);
+            enemy.memory.SetLastVisitedPoint(targetPoint);
+            waypointService.ReleasePOI(targetPoint);
+            stateMachine.ChangeState(new Enemy_SecurityGuardRest(enemy, stateMachine, waypointService));
+        }
+    }
+
+    public override void ExitState() { }
+}

--- a/Assets/Scripts/EnemyAI/States/Enemy_ReactivateSecurityMachine.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_ReactivateSecurityMachine.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+public class Enemy_ReactivateSecurityMachine : EnemyState
+{
+    private readonly SecurityMachine targetMachine;
+    private RoomWaypoint targetPoint;
+    private readonly RoomWaypoint returnPoint;
+    private bool hasArrived;
+
+    public Enemy_ReactivateSecurityMachine(
+        EnemyController enemy,
+        EnemyStateMachine machine,
+        IWaypointService waypointService,
+        SecurityMachine machineToActivate,
+        RoomWaypoint returnPoint)
+        : base(enemy, machine, waypointService)
+    {
+        targetMachine = machineToActivate;
+        this.returnPoint = returnPoint;
+    }
+
+    public override void EnterState()
+    {
+        enemy.EnemyStatus = EnemyStatus.ReactivatingMachine;
+        hasArrived = false;
+        if (targetMachine == null)
+        {
+            stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
+            return;
+        }
+        targetPoint = waypointService.GetClosestWaypoint(targetMachine.transform.position, includeUnavailable: true);
+        enemy.SetDestination(targetPoint, includeUnavailable: true);
+    }
+
+    public override void UpdateState()
+    {
+        if (hasArrived) return;
+        if (enemy.HasArrivedAtDestination())
+        {
+            hasArrived = true;
+            enemy.SetMovement(0f);
+            enemy.SetVerticalMovement(0f);
+            targetMachine.SetState(true);
+            stateMachine.ChangeState(new Enemy_ReturnToSecurityPost(enemy, stateMachine, waypointService, returnPoint));
+        }
+    }
+
+    public override void ExitState() { }
+}

--- a/Assets/Scripts/EnemyAI/States/Enemy_ReturnToSecurityPost.cs
+++ b/Assets/Scripts/EnemyAI/States/Enemy_ReturnToSecurityPost.cs
@@ -45,7 +45,7 @@ public class Enemy_ReturnToSecurityPost : EnemyState
             enemy.SetMovement(0f);
             enemy.SetVerticalMovement(0f);
             enemy.memory.SetLastVisitedPoint(targetPoint);
-            stateMachine.ChangeState(new Enemy_Idle(enemy, stateMachine, waypointService));
+            stateMachine.ChangeState(new Enemy_CheckingSecurity(enemy, stateMachine, waypointService));
         }
     }
 

--- a/Assets/Scripts/FactoryCore/RoomManager.cs
+++ b/Assets/Scripts/FactoryCore/RoomManager.cs
@@ -60,6 +60,7 @@ public class RoomManager : MonoBehaviour
         {
             spawningMachine.InitializeWaypointService(waypointService);
             spawningMachine.InitializeSpawner(enemiesSpawner);
+            spawningMachine.InitializeSecurityManager(machineSecurityManager);
             spawningWorkerManager?.RegisterMachine(spawningMachine);
         }
 
@@ -67,6 +68,12 @@ public class RoomManager : MonoBehaviour
         {
             restingMachine.InitializeWaypointService(waypointService);
             machineSecurityManager?.RegisterRestingMachine(restingMachine);
+        }
+
+        foreach (var securityMachine in securityMachinesInRoom)
+        {
+            securityMachine.InitializeWaypointService(waypointService);
+            machineSecurityManager?.RegisterSecurityMachine(securityMachine);
         }
     }
 

--- a/Assets/Scripts/Machines/SecurityMachine.cs
+++ b/Assets/Scripts/Machines/SecurityMachine.cs
@@ -10,6 +10,11 @@ public class SecurityMachine : BaseMachine
     private MeshRenderer meshRenderer;
     private EnemyController currentGuard;
 
+    public EnemyController CurrentGuard => currentGuard;
+
+    public event Action<SecurityMachine, bool> OnMachineStateChanged;
+    public event Action<SecurityMachine, EnemyController> OnMachineTurningOff;
+
     protected override void Awake()
     {
         base.Awake();
@@ -27,14 +32,18 @@ public class SecurityMachine : BaseMachine
     {
         base.PowerOn();
         ApplyMaterial();
+        OnMachineStateChanged?.Invoke(this, true);
     }
 
     public override void PowerOff()
     {
         if (!isOn) return;
         SendCurrentGuardToRest();
+        OnMachineTurningOff?.Invoke(this, currentGuard);
         base.PowerOff();
         ApplyMaterial();
+        OnMachineStateChanged?.Invoke(this, false);
+        currentGuard = null;
     }
 
     public override void AttachRobot(GameObject robot)
@@ -65,14 +74,14 @@ public class SecurityMachine : BaseMachine
     {
         if (guard == null) return;
         var sm = guard.GetComponent<EnemyStateMachine>();
-        sm?.ChangeState(new Enemy_SecurityGuardRest(guard, sm, waypointService));
+        sm?.ChangeState(new Enemy_GoingToRest(guard, sm, waypointService));
     }
 
     private void SetGuardToSecurityPost(EnemyController guard)
     {
         if (guard == null) return;
         var sm = guard.GetComponent<EnemyStateMachine>();
-        sm?.ChangeState(new Enemy_Idle(guard, sm, waypointService));
+        sm?.ChangeState(new Enemy_CheckingSecurity(guard, sm, waypointService));
     }
 
     private void SendCurrentGuardToRest()


### PR DESCRIPTION
## Summary
- add security guard states and reactivation behaviour
- enable security machines to broadcast power events
- security guards now return to CheckingSecurity after duties
- spawn machines react to disabled security machines
- add unit tests for security machines

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d5ca1d2883249c9637159830213e