### PR TITLE
Ensure factory alarm resets at level start

### DIFF
--- a/Assets/Scripts/FactoryCore/FactoryManager.cs
+++ b/Assets/Scripts/FactoryCore/FactoryManager.cs
@@ -30,10 +30,13 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
         this.mapManager = mapManager;
         this.waypointService = waypointService;
         this.victorySetup = victorySetup;
+
+        // Reset the alarm to a known state before any room logic or AI is created
+        SetupFactoryState();
+
         mapManager.InitializeGrid();
         mapManager.RegisterFactoryInEachRoom(this, machineWorkerManager, machineSecurityManager, spawningWorkerManager, enemiesSpawner);
         waypointService.BuildAllNeighbors(includeUnavailable: true);
-        SetupFactoryState();
     }
 
 


### PR DESCRIPTION
## Summary
- reset factory alarm state before generating rooms so that new scenes start in `AlarmState.Normal`

## Testing
- `dotnet test --no-build` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_6889dcd43ed483248b15226cd2fc71aa