### PR TITLE
Add SecurityBadge theft unit test

### DIFF
--- a/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs
+++ b/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class SecurityBadgeTheftTests
+{
+    private class DummyPlayerMovementController : PlayerMovementController
+    {
+        // Override lifecycle methods to avoid base behaviour
+        new void Awake() { }
+        new void OnEnable() { }
+        new void Update() { }
+    }
+
+    [Test]
+    public void StealingBadge_StartsChaseOnlyOnce()
+    {
+        // Enemy with required components
+        var enemyGO = new GameObject("enemy");
+        var enemy = enemyGO.AddComponent<EnemyController>();
+        enemyGO.AddComponent<EnemyStateMachine>();
+        enemyGO.AddComponent<RobotStateController>();
+        enemy.EnemyStatus = EnemyStatus.Idle;
+
+        // Badge attached to enemy
+        var badgeGO = new GameObject("badge");
+        badgeGO.transform.SetParent(enemyGO.transform);
+        badgeGO.AddComponent<Rigidbody2D>();
+        badgeGO.AddComponent<TargetJoint2D>();
+        var badge = badgeGO.AddComponent<SecurityBadgePickup>();
+
+        // Player hand with dummy player
+        var playerGO = new GameObject("player");
+        var playerBody = playerGO.AddComponent<Rigidbody2D>();
+        var player = playerGO.AddComponent<DummyPlayerMovementController>();
+        typeof(PlayerMovementController)
+            .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(player, playerBody);
+        var hand = new GameObject("hand").transform;
+        hand.SetParent(playerGO.transform);
+
+        int chaseCalls = 0;
+        Application.LogCallback handler = (c, s, t) => { if (c.Contains("badge stolen")) chaseCalls++; };
+        Application.logMessageReceived += handler;
+
+        badge.OnGrab(hand);
+        Assert.AreEqual(EnemyStatus.Following, enemy.EnemyStatus);
+
+        badge.OnGrab(hand); // grab again should not trigger chase again
+        badge.OnGrab(hand);
+
+        Application.logMessageReceived -= handler;
+
+        Assert.AreEqual(1, chaseCalls);
+    }
+}

--- a/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs.meta
+++ b/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8831ec8181f415dbd5679ca769a651f


### PR DESCRIPTION
## Summary
- add `SecurityBadgeTheftTests` verifying stealing a badge triggers chase once

## Testing
- `dotnet test UnitTests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f070760c83249556d3035c0fd7db