### PR TITLE
Avoid input system overhead for AI-controlled robots

### DIFF
--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -57,6 +57,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         for (int i = 0; i < workersToSpawn; i++)
         {
             var worker = ObjectPool.Instance.Get(workerPrefab, enemiesParent);
+            var locomotion = worker.GetComponent<RobotLocomotionController>();
+            if (locomotion != null)
+                locomotion.isPlayerControlled = false;
             var robotState = worker.GetComponent<RobotStateController>();
             robotState.Stats = workerRobotFactory.CreateRobot();
             robotState.Stats.RobotName = $"Worker {i + 1}";
@@ -74,6 +77,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         for (int i = 0; i < enemiesToSpawn; i++)
         {
             var enemy = ObjectPool.Instance.Get(enemyPrefab, enemiesParent);
+            var locomotion = enemy.GetComponent<RobotLocomotionController>();
+            if (locomotion != null)
+                locomotion.isPlayerControlled = false;
 
             var robotState = enemy.GetComponent<RobotStateController>();
             robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -88,6 +94,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         EnemyRobotFactory enemyRobotFactory = new EnemyRobotFactory();
 
         boosInstance = ObjectPool.Instance.Get(bossPrefab, enemiesParent);
+        var bossLocomotion = boosInstance.GetComponent<RobotLocomotionController>();
+        if (bossLocomotion != null)
+            bossLocomotion.isPlayerControlled = false;
 
         var robotState = this.boosInstance.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -125,6 +134,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
                 Vector3.zero,
                 Quaternion.identity,
                 enemiesParent);
+            var workerLocomotion = worker.GetComponent<RobotLocomotionController>();
+            if (workerLocomotion != null)
+                workerLocomotion.isPlayerControlled = false;
             var robotState = worker.GetComponent<RobotStateController>();
             robotState.Stats = workerRobotFactory.CreateRobot();
             robotState.Stats.RobotName = $"WorkerSpawner {i + 1}";
@@ -141,6 +153,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
                 Vector3.zero,
                 Quaternion.identity,
                 enemiesParent);
+        var followerLocomotion = follower.GetComponent<RobotLocomotionController>();
+        if (followerLocomotion != null)
+            followerLocomotion.isPlayerControlled = false;
 
         var robotState = follower.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -163,6 +178,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
                 Vector3.zero,
                 Quaternion.identity,
                 enemiesParent);
+        var guardLocomotion = guard.GetComponent<RobotLocomotionController>();
+        if (guardLocomotion != null)
+            guardLocomotion.isPlayerControlled = false;
 
         var robotState = guard.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -263,12 +281,19 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
     {
         // 1) Grab a worker from the pool.
         GameObject workerGO = ObjectPool.Instance.Get(workerPrefab, enemiesParent);
+        var locomotion = workerGO.GetComponent<RobotLocomotionController>();
+        if (locomotion != null)
+            locomotion.isPlayerControlled = false;
         SpawnInstanceAtRandom(workerGO);
     }
     public void SpawnBossAtRandom()
     {
         // 1) Create a fresh GameObject (no pooling; pure new instance).
         GameObject enemyGO = Instantiate(workerPrefab, Vector3.zero, Quaternion.identity, enemiesParent);
+
+        var loco = enemyGO.GetComponent<RobotLocomotionController>();
+        if (loco != null)
+            loco.isPlayerControlled = false;
 
         SpawnInstanceAtRandom(enemyGO);
     }

--- a/Assets/Scripts/Player/Core/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/Core/PlayerSpawner.cs
@@ -31,6 +31,10 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
             Quaternion.identity
         );
 
+        var locomotion = playerInstance.GetComponent<RobotLocomotionController>();
+        if (locomotion != null)
+            locomotion.isPlayerControlled = true;
+
         // Setup behaviour and save-data info
         playerRobotBehaviour = playerTemplate.InitializePlayerStateController(playerInstance);
         playerRobotInfo = playerTemplate.InitializePlayerStats(saveService.CurrentSaveData);

--- a/Assets/Scripts/RobotFactory/RobotLocomotionController.cs
+++ b/Assets/Scripts/RobotFactory/RobotLocomotionController.cs
@@ -21,6 +21,7 @@ public class RobotLocomotionController : MonoBehaviour
     public event Action OnJumpEnded;
     private RobotStateController robotBehaviour;
     private InputSystem_Actions controls;
+    [SerializeField] public bool isPlayerControlled = false;
 
     [SerializeField] private float energyCostPerStep = 1f;
     [SerializeField] private float energyCostPerJump = 3f;
@@ -34,11 +35,23 @@ public class RobotLocomotionController : MonoBehaviour
         if (robotBehaviour == null)
             Debug.LogError("RobotLocomotionController: PlayerStateController not found.");
 
-        controls = new InputSystem_Actions();
+        if (isPlayerControlled)
+        {
+            controls = new InputSystem_Actions();
+        }
     }
 
-    private void OnEnable() => controls.Enable();
-    private void OnDisable() => controls.Disable();
+    private void OnEnable()
+    {
+        if (isPlayerControlled && controls != null)
+            controls.Enable();
+    }
+
+    private void OnDisable()
+    {
+        if (isPlayerControlled && controls != null)
+            controls.Disable();
+    }
 
     #region Movement
 
@@ -168,9 +181,12 @@ public class RobotLocomotionController : MonoBehaviour
         isJumping = false;
         StopWalking();
 
-        float input = controls.Player.Move.ReadValue<Vector2>().x;
-        if (Mathf.Abs(input) > 0.2f)
-            HandleMovement(input);
+        if (isPlayerControlled && controls != null)
+        {
+            float input = controls.Player.Move.ReadValue<Vector2>().x;
+            if (Mathf.Abs(input) > 0.2f)
+                HandleMovement(input);
+        }
 
         OnJumpEnded?.Invoke();
     }


### PR DESCRIPTION
## Summary
- add `isPlayerControlled` flag in `RobotLocomotionController`
- only initialize and enable input actions for player-controlled robots
- set `isPlayerControlled` in `PlayerSpawner` and `EnemiesSpawner`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fd99ebdc8324b057904c406f0ad9