### PR TITLE
Fix GitHub Actions step naming

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: game-ci/unity-test-runner@v4
+    - name: Run Unity Tests
+      uses: game-ci/unity-test-runner@v4
       with:
         unityVersion: 2023.2.0f1
         testMode: editmode


### PR DESCRIPTION
## Summary
- add a `name` to the Unity test step in `unity-tests.yml`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a1ca74fb88324a8409b28d09d6344