### PR TITLE
Fix spawner locomotion setup for animator prefabs

### DIFF
--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -58,9 +58,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         for (int i = 0; i < workersToSpawn; i++)
         {
             var worker = ObjectPool.Instance.Get(workerPrefab, enemiesParent);
-            var locomotion = worker.GetComponent<RobotLocomotionController>();
-            if (locomotion != null)
-                locomotion.isPlayerControlled = false;
+            // Animator-based prefabs may not have a locomotion component.
             var robotState = worker.GetComponent<RobotStateController>();
             robotState.Stats = workerRobotFactory.CreateRobot();
             robotState.Stats.RobotName = $"Worker {i + 1}";
@@ -78,10 +76,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         for (int i = 0; i < enemiesToSpawn; i++)
         {
             var enemy = ObjectPool.Instance.Get(enemyPrefab, enemiesParent);
-            var locomotion = enemy.GetComponent<RobotLocomotionController>();
-            if (locomotion != null)
-                locomotion.isPlayerControlled = false;
-
+            // Animator-based prefabs may omit locomotion.
             var robotState = enemy.GetComponent<RobotStateController>();
             robotState.Stats = enemyRobotFactory.CreateRobot();
             robotState.Stats.RobotName = $"Enemy {i + 1}";
@@ -127,9 +122,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
                 Vector3.zero,
                 Quaternion.identity,
                 enemiesParent);
-            var workerLocomotion = worker.GetComponent<RobotLocomotionController>();
-            if (workerLocomotion != null)
-                workerLocomotion.isPlayerControlled = false;
+            // Worker spawner prefabs may lack locomotion.
             var robotState = worker.GetComponent<RobotStateController>();
             robotState.Stats = workerRobotFactory.CreateRobot();
             robotState.Stats.RobotName = $"WorkerSpawner {i + 1}";
@@ -146,9 +139,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         spawnedFollowers.Clear();
 
         var follower = ObjectPool.Instance.Get(enemyPrefab, enemiesParent);
-        var locomotion = follower.GetComponent<RobotLocomotionController>();
-        if (locomotion != null)
-            locomotion.isPlayerControlled = false;
+        // Animator-based followers don't need locomotion configuration.
 
         var robotState = follower.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -179,9 +170,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
                 Vector3.zero,
                 Quaternion.identity,
                 enemiesParent);
-        var guardLocomotion = guard.GetComponent<RobotLocomotionController>();
-        if (guardLocomotion != null)
-            guardLocomotion.isPlayerControlled = false;
+        // Security guard prefabs may omit locomotion.
 
         var robotState = guard.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
@@ -287,9 +276,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
     {
         // 1) Grab a worker from the pool.
         GameObject workerGO = ObjectPool.Instance.Get(workerPrefab, enemiesParent);
-        var locomotion = workerGO.GetComponent<RobotLocomotionController>();
-        if (locomotion != null)
-            locomotion.isPlayerControlled = false;
+        // Animator-based prefabs don't require locomotion setup.
         SpawnInstanceAtRandom(workerGO);
     }
     public void SpawnBossAtRandom()
@@ -297,9 +284,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         // 1) Create a fresh GameObject (no pooling; pure new instance).
         GameObject enemyGO = Instantiate(workerPrefab, Vector3.zero, Quaternion.identity, enemiesParent);
 
-        var loco = enemyGO.GetComponent<RobotLocomotionController>();
-        if (loco != null)
-            loco.isPlayerControlled = false;
+        // Animator-based prefabs don't require locomotion setup.
 
         SpawnInstanceAtRandom(enemyGO);
     }


### PR DESCRIPTION
## Summary
- avoid touching locomotion on animator-based enemy and worker prefabs
- clarify that these prefabs may omit locomotion components

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b32c6ac0483249a78c2a1da12f073