### PR TITLE
Fix Singleton by using FindFirstObjectByType

### DIFF
--- a/Assets/UpdateManager/Scripts/Utility/Singleton.cs
+++ b/Assets/UpdateManager/Scripts/Utility/Singleton.cs
@@ -25,7 +25,7 @@ namespace JoostenProductions {
                 lock (objectLock) {
                     if(instance != null) return instance;
 
-                    instance = (T)FindObjectOfType(instanceType);
+                    instance = (T)FindFirstObjectByType(instanceType);
 
                     if(instance != null) return instance;
 


### PR DESCRIPTION
## Summary
- use `FindFirstObjectByType` in `Singleton` to avoid obsolete API

## Testing
- `setup_env.sh` *(fails: package install errors)*
- `unity -runTests -testPlatform EditMode -projectPath "$PWD" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b3bf08114832487420225430a714b