### PR TITLE
Remove 'new' modifiers from test dummy

### DIFF
--- a/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs
+++ b/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs
@@ -7,9 +7,9 @@ public class SecurityBadgeTheftTests
     private class DummyPlayerMovementController : PlayerMovementController
     {
         // Override lifecycle methods to avoid base behaviour
-        new void Awake() { }
-        new void OnEnable() { }
-        new void Update() { }
+        void Awake() { }
+        void OnEnable() { }
+        void Update() { }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- update `SecurityBadgeTheftTests` so dummy controller methods don't use the `new` keyword

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b3dcfd0548324b89d490dfed23547