### PR TITLE
Fix teleport scene references

### DIFF
--- a/Assets/Scripts/Game/TeleportToBaseCamp.cs
+++ b/Assets/Scripts/Game/TeleportToBaseCamp.cs
@@ -1,12 +1,12 @@
 using UnityEngine;
 
-public class TeleportToBaseCap : MonoBehaviour
+public class TeleportToBaseCamp : MonoBehaviour
 {
     private void OnTriggerEnter2D(Collider2D collision)
     {
         if (collision.CompareTag("Player"))
         {
-            SceneController.instance.LoadScene("BaseCampScene");
+            SceneController.instance.LoadScene("SetupSandbox");
         }
     }
 }

--- a/Assets/Scripts/Game/TeleportToFactoryEntrance.cs
+++ b/Assets/Scripts/Game/TeleportToFactoryEntrance.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
+
 
 public class TeleportToFactoryEntrance : MonoBehaviour
 {
@@ -7,7 +7,7 @@ public class TeleportToFactoryEntrance : MonoBehaviour
     {
         if (collision.CompareTag("Player"))
         {
-            SceneController.instance.LoadScene("FactoryEntrance");
+            SceneController.instance.LoadScene("MapGeneration");
         }
     }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,15 +8,6 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MenuScene.unity
     guid: 8c9cfa26abfee488c85f1582747f6a02
-  - enabled: 0
-    path: Assets/Scenes/BaseCampScene.unity
-    guid: f07f53990dcae9842adf843a8453f1e0
-  - enabled: 0
-    path: Assets/Scenes/FactoryEntrance.unity
-    guid: e94c900727e1e2742b7ccc3189baff2d
-  - enabled: 0
-    path: Assets/Scenes/Laboratory.unity
-    guid: 94ca5bb851d256e4ab2e562f42f95bcb
   - enabled: 1
     path: Assets/Scenes/SetupSandbox.unity
     guid: 413c3c93b7f36bd4b9e4edd20a65c383


### PR DESCRIPTION
## Summary
- redirect TeleportToBaseCamp to `SetupSandbox`
- load `MapGeneration` from TeleportToFactoryEntrance
- clean up build settings to remove unused scene entries

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b410c045c8324837dd4f899dfa39a