### PR TITLE
Fix missing script in Enemy prefab

### DIFF
--- a/Assets/Resources/Prefabs/Setup/Enemy.prefab
+++ b/Assets/Resources/Prefabs/Setup/Enemy.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9061588516511059660}
-  - component: {fileID: 5113994695770173855}
   - component: {fileID: 6258465891312467843}
   - component: {fileID: 6258465891312467844}
   - component: {fileID: 6258465891312467845}
@@ -36,18 +35,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5113994695770173855
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4614694437722500152}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c572e48d2bdbd504bb569078ed516361, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
 --- !u!95 &6258465891312467843
 Animator:
   serializedVersion: 7


### PR DESCRIPTION
## Summary
- strip the invalid Enemy behaviour from the `Enemy.prefab`

Identified GUID mappings:
- `0cd44c1031e13a943bb63640046fad76` → `CanvasScaler`
- `c698c0105d4eae94fb07cc05d62fa3e0` → `TargetAim`
- `c572e48d2bdbd504bb569078ed516361` referenced a deleted script and was removed

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b42412248832481b5ae08cfbbaa99