### PR TITLE
Improve shader performance for path and polygon rendering

### DIFF
--- a/Assets/Shapes2D/Shaders/Path.cginc
+++ b/Assets/Shapes2D/Shaders/Path.cginc
@@ -124,6 +124,7 @@ float2 distance_to_path(float2 pos) {
     // you can't do variable-length loops in webgl (or es2 technically I think), 
     // hence the constant...so we have to iterate through MAX_SEGMENTS rather than 
     // _NumSegments which is the number of vertices actually in our poly
+    UNITY_LOOP
     for (int i = 0; i < MAX_SEGMENTS; i++) {
         // loop_over is 1 when we're past the number of sides in the poly
         float loop_over = when_ge(i, _NumSegments);

--- a/Assets/Shapes2D/Shaders/Polygon.cginc
+++ b/Assets/Shapes2D/Shaders/Polygon.cginc
@@ -29,6 +29,7 @@ float get_closest_distance(float2 pos, float2 radii) {
     // you can't do variable-length loops in webgl (or es2 technically I think), 
     // hence the constant...so we have to iterate through MAX_VERTS rather than 
     // _NumVerts which is the number of vertices actually in our poly
+    UNITY_LOOP
     for (int i = 0; i < MAX_VERTS; i++) {
         // loop_over is 1 when we're past the number of sides in the poly
         float loop_over = when_ge(i, _NumVerts);
@@ -57,7 +58,8 @@ float get_closest_distance(float2 pos, float2 radii) {
         // if (i == _NumVerts - 1)
         //     break;
     }
-    return closest_distance * when_eq(nodes % 2, 1) + -1 * when_neq(nodes % 2, 1);
+    int parity = nodes & 1;
+    return closest_distance * when_eq(parity, 1) + -1 * when_neq(parity, 1);
 }
 
 // tells you which side of the line p1->p2 pos is


### PR DESCRIPTION
## Summary
- use `UNITY_LOOP` to allow loop iteration without forced unrolling
- replace modulus with bitwise operation in polygon shader

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b4dab98fc8324bfcbe41b2dbd9f0a