### PR TITLE
Ensure minimap preview covers container

### DIFF
--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -154,7 +154,7 @@ public class GameUIViewModel : MonoBehaviour
         if (previewVE != null)
         {
             previewVE.style.backgroundImage = new StyleBackground(tex);
-            previewVE.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
+            previewVE.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Cover);
         }
         else
         {

--- a/Assets/Scripts/UI/RunSetupManager.cs
+++ b/Assets/Scripts/UI/RunSetupManager.cs
@@ -411,7 +411,7 @@ public class RunSetupManager : MonoBehaviour
         RenderTexture.active = prev;
 
         previewVE.style.backgroundImage = new StyleBackground(tex);
-        previewVE.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Contain);
+        previewVE.style.backgroundSize = new BackgroundSize(BackgroundSizeType.Cover);
         BackgroundPosition center = new BackgroundPosition(BackgroundPositionKeyword.Center);
     }
 


### PR DESCRIPTION
## Summary
- adjust minimap preview background sizing to use `Cover`
- keep UI binding logic intact

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b0e0aa1bc832488394599e5efe351