### PR TITLE
Revert enemies to physics controllers

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -2,16 +2,11 @@ using UnityEngine;
 using System.Collections;
 
 [RequireComponent(typeof(WorkerStateMachine), typeof(RobotMemory))]
-public class EnemyWorkerController : AnimatorBaseAgentController
+public class EnemyWorkerController : PhysicsBaseAgentController
 {
     [SerializeField] public WorkerStateMachine stateMachine;
     [SerializeField] private RobotMemory memoryComponent;
-
-    [SerializeField] private FacingController facing;
-    [SerializeField] private LegJointLimiter legJointLimiter;
-    [SerializeField] private BodyJointLimiter bodyJointLimiter;
-
-    private bool flipped = false;
+    [SerializeField] private Transform bodyReference;
 
     private IWorkerStateMachine stateMachineInterface;
     public IRobotMemory memory { get; private set; }
@@ -31,8 +26,9 @@ public class EnemyWorkerController : AnimatorBaseAgentController
 
     [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
 
-    private void Awake()
+    protected override void Awake()
     {
+        base.Awake();
         if (stateMachine == null)
             stateMachine = GetComponent<WorkerStateMachine>();
         stateMachineInterface = stateMachine;
@@ -40,15 +36,6 @@ public class EnemyWorkerController : AnimatorBaseAgentController
         if (memoryComponent == null)
             memoryComponent = GetComponent<RobotMemory>();
         memory = memoryComponent;
-
-        animator = GetComponentInChildren<Animator>();
-
-        if (facing == null)
-            facing = GetComponent<FacingController>();
-        if (legJointLimiter == null)
-            legJointLimiter = GetComponent<LegJointLimiter>();
-        // if (bodyJointLimiter == null)
-        //     bodyJointLimiter = GetComponent<BodyJointLimiter>();
 
         robotBehaviour.OnStateChanged += HandleStateChange;
     }
@@ -70,10 +57,8 @@ public class EnemyWorkerController : AnimatorBaseAgentController
         IsWorkerSpawner = true;
     }
 
-    protected override void Update()
+    private void Update()
     {
-        base.Update();
-        TryFlip(direction);
         if (updateLoop == UpdateLoop.Update)
             pathFollower?.Update(Time.deltaTime);
     }
@@ -95,29 +80,6 @@ public class EnemyWorkerController : AnimatorBaseAgentController
 
     public RoomWaypoint GetClosestWaypoint(RoomWaypoint exclude = null) =>
         pathFollower.GetClosestWaypoint(exclude);
-
-    private void TryFlip(float input)
-    {
-        if (Mathf.Abs(input) > 0.1f)
-        {
-            bool movingLeft = input < 0f;
-            if (movingLeft != flipped)
-            {
-                flipped = movingLeft;
-                ApplyFacingDirection();
-            }
-        }
-    }
-
-    private void ApplyFacingDirection()
-    {
-        if (facing != null)
-            facing.SetLegFacing(!flipped);
-        if (legJointLimiter != null)
-            legJointLimiter.SetLegRotationLimits(flipped);
-        if (bodyJointLimiter != null)
-            bodyJointLimiter.SetBodyRotationLimits(flipped);
-    }
 
     private void HandleStateChange(RobotState newState)
     {
@@ -153,14 +115,6 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     {
         yield return new WaitForSeconds(5f);
         ObjectPool.Instance.Release(gameObject);
-    }
-
-    private void DisableAnimator()
-    {
-        if (animator != null)
-        {
-            animator.enabled = false;
-        }
     }
 
     private void UpdateBalance(bool enabledBalance)


### PR DESCRIPTION
## Summary
- revert enemy and worker AI controllers to physics-based movement
- trim animator-specific logic from enemy scripts

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c81cc79048324bd3051aafb7a82be