### PR TITLE
feat: add worker flee state

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/LowMoralityPlayerTriggerHandler.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/LowMoralityPlayerTriggerHandler.cs
@@ -1,0 +1,35 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Detects players within a radius and notifies when their morality is low.
+/// </summary>
+public class LowMoralityPlayerTriggerHandler : MonoBehaviour
+{
+    [Header("Zone Detection")]
+    public PositionTriggerZone detectZone;
+    public float radius = 10f;
+
+    public event Action<Transform> OnLowMoralityPlayerDetected;
+
+    private void Start()
+    {
+        if (detectZone != null)
+        {
+            detectZone.zoneSize = Vector2.one * radius * 2f;
+            detectZone.onEnter.AddListener(OnPlayerEnterDetectZone);
+        }
+    }
+
+    private void OnPlayerEnterDetectZone(Collider2D collider)
+    {
+        if (!collider.CompareTag("Player"))
+            return;
+
+        var playerController = collider.transform.root.GetComponent<RobotStateController>();
+        if (playerController != null && playerController.Stats.Morality <= -5f)
+        {
+            OnLowMoralityPlayerDetected?.Invoke(playerController.transform);
+        }
+    }
+}

--- a/Assets/Scripts/EnemyAI/Controllers/LowMoralityPlayerTriggerHandler.cs.meta
+++ b/Assets/Scripts/EnemyAI/Controllers/LowMoralityPlayerTriggerHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 178ec67020654ef49284b6e39cbb36be

--- a/Assets/Scripts/EnemyAI/States/WorkerState.cs
+++ b/Assets/Scripts/EnemyAI/States/WorkerState.cs
@@ -27,6 +27,7 @@ public enum WorkerStatus
     GoingToRest,
     Idle,
     Resting,
+    RunningAway,
     ReadyToSpawnFollowers,
     GoingToStartRoom,
     Saved,

--- a/Assets/Scripts/EnemyAI/States/Worker_FleePlayer.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_FleePlayer.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+
+/// <summary>
+/// Worker flees from the player when they exhibit low morality.
+/// </summary>
+public class Worker_FleePlayer : WorkerState
+{
+    private readonly WorkerState previousState;
+    private readonly Transform player;
+    private readonly FactoryMachine storedMachine;
+    private bool machineReleased;
+
+    public Worker_FleePlayer(EnemyWorkerController enemy,
+                             WorkerStateMachine machineSM,
+                             IWaypointService waypointService,
+                             WorkerState previousState,
+                             Transform player,
+                             FactoryMachine currentMachine)
+        : base(enemy, machineSM, waypointService)
+    {
+        this.previousState = previousState;
+        this.player = player;
+        storedMachine = currentMachine;
+        machineReleased = currentMachine == null;
+    }
+
+    public override void EnterState()
+    {
+        enemy.workerState = WorkerStatus.RunningAway;
+
+        if (!machineReleased && storedMachine != null)
+        {
+            machineReleased = true;
+            storedMachine.ReleaseRobot();
+            enemy.ClearCurrentMachine();
+            stateMachine.ChangeState(this);
+            return;
+        }
+
+        enemy.SetDestination(GetFleeWaypoint(), includeUnavailable: true);
+
+        var audio = enemy.GetComponent<AudioSource>();
+        audio?.Play();
+    }
+
+    private RoomWaypoint GetFleeWaypoint()
+    {
+        Vector2 direction = (enemy.transform.position - player.position).normalized;
+        Vector2 targetPosition = (Vector2)enemy.transform.position + direction * 12f;
+        return waypointService.GetClosestWaypoint(targetPosition, includeUnavailable: true);
+    }
+
+    public override void UpdateState()
+    {
+        if (Vector2.Distance(enemy.transform.position, player.position) > 10f)
+        {
+            if (storedMachine != null)
+            {
+                stateMachine.ChangeState(new Worker_GoingToMachine(enemy, stateMachine, waypointService, storedMachine));
+            }
+            else
+            {
+                stateMachine.ChangeState(previousState);
+            }
+            return;
+        }
+
+        if (enemy.HasArrivedAtDestination())
+        {
+            enemy.SetDestination(GetFleeWaypoint(), includeUnavailable: true);
+        }
+    }
+
+    public override void ExitState()
+    {
+        enemy.SetMovement(0f);
+        enemy.SetVerticalMovement(0f);
+    }
+}

--- a/Assets/Scripts/EnemyAI/States/Worker_FleePlayer.cs.meta
+++ b/Assets/Scripts/EnemyAI/States/Worker_FleePlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 984d4932d8f043fd918dcb14641454a2

--- a/Assets/Scripts/Machines/FactoryMachine.cs
+++ b/Assets/Scripts/Machines/FactoryMachine.cs
@@ -114,6 +114,7 @@ public class FactoryMachine : BaseMachine
     private void SetWorkerToWork(EnemyWorkerController worker)
     {
         if (worker == null) return;
+        worker.SetCurrentMachine(this);
         worker.stateMachine.ChangeState(
             new Worker_IsWork(worker, worker.stateMachine, worker.waypointService));
     }

--- a/Game.csproj
+++ b/Game.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Assets\Scripts\Navigation\LockEndRoomDoorProcessor.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToMachine.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToRestStation.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\States\Worker_FleePlayer.cs" />
     <Compile Include="Assets\Scripts\Map\DoorDirection.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Worker_Saved.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\ReactiveMachineAI.cs" />
@@ -262,6 +263,7 @@
     <Compile Include="Assets\Scripts\Services\SecurityBadgeSpawner.cs" />
     <Compile Include="Assets\Scripts\Robots\Hinge2DIkSolver.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\FollowPlayerTriggerHandler.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\Controllers\LowMoralityPlayerTriggerHandler.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToLeastWorkedStation.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Enemy_CheckingSecurity.cs" />
     <Compile Include="Assets\Scripts\FactoryCore\FactoryManager.cs" />


### PR DESCRIPTION
## Summary
- detect low-morality players and raise event
- add worker flee state and supporting controller hooks
- track and release current machines when fleeing

## Testing
- `bash ./setup_env.sh >/tmp/setup.log && tail -n 20 /tmp/setup.log` (failed: Package 'libasound2' has no installation candidate)
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6890891bd5fc8324a9071bc4e82ab8ee