### PR TITLE
feat: add ally controller for navigation

### DIFF
--- a/Assets/Scripts/Ally.meta
+++ b/Assets/Scripts/Ally.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d678d6a030f547919404a336c0633dd1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Ally/Controllers.meta
+++ b/Assets/Scripts/Ally/Controllers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f93d2b5ad2eb4b8fa85aeb16a96b29e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Ally/Controllers/AllyController.cs
+++ b/Assets/Scripts/Ally/Controllers/AllyController.cs
@@ -1,0 +1,96 @@
+using UnityEngine;
+
+/// <summary>
+/// Controls allied robot navigation and interactions with machines.
+/// Uses <see cref="WaypointPathFollower"/> for navigation while avoiding any
+/// player specific logic.
+/// </summary>
+public class AllyController : PhysicsBaseAgentController
+{
+    [SerializeField] private Transform bodyReference;
+    [SerializeField] private float arrivalThresholdX = 2f;
+    [SerializeField] private float arrivalThresholdY = 2f;
+    [SerializeField] private float deadZoneX = 5f;
+    [SerializeField] private float deadZoneY = 5f;
+    [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
+
+    private WaypointPathFollower pathFollower;
+    private IWaypointQueries waypointQueries;
+    private IWaypointNotifier waypointNotifier;
+    private IWaypointService waypointService;
+
+    protected override void Awake()
+    {
+        base.Awake();
+    }
+
+    /// <summary>
+    /// Initializes navigation services and subscribes to waypoint updates.
+    /// </summary>
+    public void Initialize(IWaypointService service)
+    {
+        waypointService = service;
+        waypointQueries = service;
+        waypointNotifier = service;
+        pathFollower = new WaypointPathFollower(bodyReference, this, waypointQueries,
+            arrivalThresholdX, arrivalThresholdY, deadZoneX, deadZoneY);
+        waypointNotifier.Subscribe(pathFollower);
+    }
+
+    private void Update()
+    {
+        TryFlip(direction);
+        if (updateLoop == UpdateLoop.Update)
+            pathFollower?.Update(Time.deltaTime);
+    }
+
+    private void FixedUpdate()
+    {
+        if (updateLoop == UpdateLoop.FixedUpdate)
+            pathFollower?.Update(Time.fixedDeltaTime);
+    }
+
+    /// <summary>
+    /// Sets a waypoint destination for the ally.
+    /// </summary>
+    public void SetDestination(RoomWaypoint target, bool includeUnavailable = false) =>
+        pathFollower?.SetDestination(target, includeUnavailable);
+
+    /// <summary>
+    /// Notifies the controller that a path has become blocked.
+    /// </summary>
+    public void OnPathObsoleted(RoomWaypoint blockedWaypoint) =>
+        pathFollower?.OnPathObsoleted(blockedWaypoint);
+
+    /// <summary>
+    /// Gets the closest waypoint to the ally.
+    /// </summary>
+    public RoomWaypoint GetClosestWaypoint(RoomWaypoint exclude = null) =>
+        pathFollower?.GetClosestWaypoint(exclude);
+
+    private void OnTriggerEnter2D(Collider2D collision) => HandleMachineTrigger(collision);
+
+    private void OnTriggerExit2D(Collider2D collision) => HandleMachineTrigger(collision);
+
+    private void HandleMachineTrigger(Collider2D collision)
+    {
+        var machine = collision.GetComponentInParent<BaseMachine>();
+        if (machine == null)
+            return;
+
+        machine.SetState(false);
+        if (waypointService == null)
+            return;
+
+        if (machine is FactoryMachine factory)
+        {
+            waypointService.ReleaseMachine(factory);
+        }
+        else
+        {
+            var poi = waypointService.GetClosestWaypoint(machine.transform.position);
+            waypointService.ReleasePOI(poi);
+        }
+    }
+}
+

--- a/Assets/Scripts/Ally/Controllers/AllyController.cs.meta
+++ b/Assets/Scripts/Ally/Controllers/AllyController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4e1429c14f0645339db44a757fbdebbe


### PR DESCRIPTION
## Summary
- implement AllyController inheriting from PhysicsBaseAgentController
- turn off machines and release waypoint reservations on trigger
- integrate WaypointPathFollower for ally movement

## Testing
- `bash setup_env.sh` *(failed: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68909ca934d483249afc71c95175b258