### PR TITLE
Implement joint restoration for pooled enemies

### DIFF
--- a/Assets/Scripts/EnemyAI/PooledEnemy.cs
+++ b/Assets/Scripts/EnemyAI/PooledEnemy.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class PooledEnemy : MonoBehaviour, IPooledObject
@@ -14,21 +12,6 @@ public class PooledEnemy : MonoBehaviour, IPooledObject
     private Transform[] cachedTransforms;
     private Vector3[] defaultPositions;
     private Quaternion[] defaultRotations;
-
-    private class JointInfo
-    {
-        public GameObject owner;
-        public Type type;
-        public Rigidbody2D connectedBody;
-        public Vector2 anchor;
-        public Vector2 connectedAnchor;
-        public float breakForce;
-        public float breakTorque;
-        public bool enableCollision;
-        public bool autoConfigure;
-    }
-
-    private readonly List<JointInfo> joints = new();
 
     private void Awake()
     {
@@ -52,22 +35,6 @@ public class PooledEnemy : MonoBehaviour, IPooledObject
         {
             defaultPositions[i] = cachedTransforms[i].localPosition;
             defaultRotations[i] = cachedTransforms[i].localRotation;
-        }
-
-        foreach (var joint in GetComponentsInChildren<Joint2D>(true))
-        {
-            joints.Add(new JointInfo
-            {
-                owner = joint.gameObject,
-                type = joint.GetType(),
-                connectedBody = joint.connectedBody,
-                anchor = joint.anchor,
-                connectedAnchor = joint.connectedAnchor,
-                breakForce = joint.breakForce,
-                breakTorque = joint.breakTorque,
-                enableCollision = joint.enableCollision,
-                autoConfigure = joint.autoConfigureConnectedAnchor
-            });
         }
     }
 
@@ -93,34 +60,7 @@ public class PooledEnemy : MonoBehaviour, IPooledObject
 
     public void OnAcquireFromPool()
     {
-        foreach (var info in joints)
-        {
-            var component = info.owner.GetComponent(info.type);
-            Joint2D joint = component as Joint2D;
-            if (joint == null)
-                joint = info.owner.AddComponent(info.type) as Joint2D;
-            if (joint == null)
-                continue;
-            joint.connectedBody = info.connectedBody;
-            joint.anchor = info.anchor;
-            joint.connectedAnchor = info.connectedAnchor;
-            joint.breakForce = info.breakForce;
-            joint.breakTorque = info.breakTorque;
-            joint.enableCollision = info.enableCollision;
-            joint.autoConfigureConnectedAnchor = info.autoConfigure;
-        }
-
-        if (jointBreaker != null)
-        {
-            jointBreaker.hingeJoints.Clear();
-            jointBreaker.hingeJoints.AddRange(GetComponentsInChildren<HingeJoint2D>());
-            jointBreaker.fixedJoints.Clear();
-            jointBreaker.fixedJoints.AddRange(GetComponentsInChildren<FixedJoint2D>());
-            jointBreaker.ikSolvers.Clear();
-            jointBreaker.ikSolvers.AddRange(GetComponentsInChildren<Hinge2DIkSolver>());
-            foreach (var solver in jointBreaker.ikSolvers)
-                if (solver != null) solver.enabled = true;
-        }
+        jointBreaker?.RestoreAll();
 
         if (animator != null)
         {


### PR DESCRIPTION
## Summary
- add RestoreAll to JointBreaker that caches joints during Awake and restores their settings and IK solvers
- invoke JointBreaker.RestoreAll in PooledEnemy.OnAcquireFromPool to rebuild limb connections on reuse

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ab85f55c83249b424d2bc7be209a